### PR TITLE
MIP-02: Clarify Welcome gift-wrap signing requirement

### DIFF
--- a/02.md
+++ b/02.md
@@ -28,6 +28,10 @@ This sequencing prevents race conditions where a new member receives a Welcome f
 Welcome Events use [NIP-59](https://github.com/nostr-protocol/nips/blob/master/59.md) gift-wrapping for privacy and unlinkability.
 ## Welcome Event Structure
 
+### Rumor (Inner Welcome Event)
+
+The Welcome information lives inside an unsigned `kind: 444` rumor event:
+
 ```json
 {
   "id": "def456...",
@@ -38,12 +42,35 @@ Welcome Events use [NIP-59](https://github.com/nostr-protocol/nips/blob/master/5
   "tags": [
     ["e", "keypackage_event_id_123..."],
     ["relays", "wss://relay1.com", "wss://relay2.com"]
-  ],
-  "sig": "304502210..."
+  ]
 }
 ```
 
-**Signing requirement**: This outer NIP-59 wrapper MUST be signed following the standard gift-wrap flow so relays will accept it and recipients can authenticate the sender. The inner gift-wrapped payload remains encrypted and authenticated solely for the intended recipient.
+### Gift Wrap (Relay-Facing Envelope)
+
+Wrap the rumor following [NIP-59](https://github.com/nostr-protocol/nips/blob/master/59.md):
+
+1. Encrypt the rumor into a `kind: 13` seal signed by the inviter’s identity key.
+2. Encrypt the seal into a `kind: 1059` gift wrap signed by a single-use wrapper key. This is the only event relays see.
+
+```json
+{
+  "id": "wrap123...",
+  "kind": 1059,
+  "created_at": 1693876601,
+  "pubkey": "11aa22bb33cc44dd55ee66ff77889900aabbccddeeff00112233445566778899",
+  "content": "Encrypted kind-13 seal containing the rumor",
+  "tags": [
+    ["p", "invited_member_pubkey"]
+  ],
+  "sig": "6b9450..."
+}
+```
+
+**Signing requirements**:
+- The rumor remains unsigned to preserve NIP-59 deniability.
+- The `kind: 13` seal MUST be signed by the inviter (authenticating the Welcome).
+- The `kind: 1059` gift wrap MUST be signed by its wrapper key so relays will accept and deliver it.
 
 ### Field Details
 


### PR DESCRIPTION
### Warning

:warning: Hallucinations may be present, or all encompassing. This is not reviewed by professional devs, or cryptographers. Proceed at own risk :warning:.

## Overview

  - Adds the missing sig field to the Welcome gift-wrap example in MIP-02.
  - Replaces the “do not sign” note with explicit guidance that the outer NIP-59 wrapper must be signed so relays will accept it and recipients can
    authenticate the sender.
  - Notes that the inner payload remains encrypted and authenticated solely for the intended invitee.

###  Problem
  The original doc told implementers to leave the wrapper unsigned while also mandating NIP-59. Unsigned gift-wrap events are rejected by most relays
  and fail client validation, so Welcomes generated per spec could never be delivered—blocking new members from joining groups. If this isn’t fixed,
  admins will believe they’ve invited someone, but the Welcome never lands, so the user can’t join, group creation stalls, and the protocol appears
  broken.

###  Benefit
  With the wrapper signed, Welcome messages reliably pass relay validation and reach invitees, enabling group onboarding to work as intended while
  keeping the MLS Welcome payload unchanged.

###  Tradeoffs / Privacy Considerations

  - Signing the wrapper doesn’t expose new metadata: relays already see the sender’s key, timestamp, tags, and ciphertext whether a sig is present or not.
  - The encrypted Welcome contents remain private and deniable within NIP-59’s standard model. For deployments that want additional deniability, the spec still allows publishing via an ephemeral wrapper key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Welcome Event JSON structure with a new top-level signature field.
  * Welcome Events now require outer NIP-59 wrapper signing via the gift-wrap flow, with inner payload encryption maintained for intended recipients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->