### PR TITLE
MIP-00: Clarify BasicCredential identity encoding

### DIFF
--- a/00.md
+++ b/00.md
@@ -15,9 +15,11 @@ MLS `Credentials` link Nostr identities to group-specific signing keys, function
 When creating credentials, clients MUST:
 
 - **Use BasicCredential type**: The standard MLS credential format
-- **Set identity to Nostr pubkey**: Use the 32-byte hex-encoded public key of the user's Nostr identity
+- **Set identity to Nostr pubkey**: Write the user's Nostr public key as exactly 32 raw bytes in the BasicCredential `identity` field. If your application stores keys as 64-character hex strings, decode the hex to bytes before serializing.
 - **Keep identity immutable**: Never allow changes to the identity field
 - **Validate proposals**: Reject any `Proposal` or `Commit` that attempts to change identity fields
+
+> _Implementation note_: MLS encodes the BasicCredential identity as opaque bytes, so all implementations must emit the same 32-byte value. Comparing the raw bytes (not their hex representation) ensures credentials issued by different clients remain interoperable.
 
 ### Signing Keys
 


### PR DESCRIPTION
### Warning
⚠️ Hallucinations may be present, or all encompassing. This is not reviewed by professional devs, or cryptographers. Proceed at own risk ⚠️.

## Problem

  - MIP-00 told implementers to “use the 32-byte hex-encoded public key” inside an MLS BasicCredential. The identity field actually stores raw bytes,
    so one client might write 32 raw bytes while another writes a 64-character hex string. That mismatch causes credential comparisons to fail,
    breaking interoperability.

###  Solution

  - Updated the spec to say “write the user’s Nostr public key as exactly 32 raw bytes,” and added a note reminding implementers to decode any hex
    representation before serialization and to compare the raw bytes.

###  Benefit

  - Every implementation now produces the same canonical credential identity, so MLS membership checks work across clients.

 ### Tradeoffs

  - None; the change merely makes the intended encoding explicit.

  ### If Not Implemented

  - Clients may continue to serialize different representations, so group membership validation will fail whenever participants use different software.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated identity serialization guidance to specify 32 raw bytes format for BasicCredential identity fields
  * Added implementation notes clarifying MLS identity encoding as opaque bytes for cross-implementation consistency
  * Added instructions for converting hex-encoded keys to raw bytes format when necessary before serialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->