### PR TITLE
Allow Marmot Group Data extension to accept trailing fields

### DIFF
--- a/01.md
+++ b/01.md
@@ -235,13 +235,19 @@ function validate_structure(data, version) {
 
     // Check remaining fixed fields fit
     REMAINING_FIXED = 32 + 32 + 12  // image_hash + image_key + image_nonce
-    return (offset + REMAINING_FIXED == data.length)
+    offset += REMAINING_FIXED
+    if (offset > data.length) return false
+
+    // Allow future versions to append additional data after known fields
+    // (callers can decide whether to parse or ignore the surplus bytes)
+    return true
 }
 ```
 
 **Forward Compatibility**: When encountering unknown future versions:
 - Parse known fields in order (version, nostr_group_id, name, description, admin_pubkeys, relays, image_hash, image_key, image_nonce)
 - Ignore additional unknown fields
+- Treat any remaining bytes after `image_nonce` as opaque future data (do not fail validation)
 - Continue normal operation with available data
 - Log warning about unknown version for debugging
 


### PR DESCRIPTION
## Warning
⚠️ Hallucinations may be present, or all encompassing. This is not reviewed by professional devs, or cryptographers. Proceed at own risk ⚠️.

## Problem
    Forward-compatibility pseudocode in MIP-01 rejected any extension blob whose length exceeded the current fields, contradicting the spec’s claim
    that future fields could be appended.
### Solution
    Adjusted the validation logic so it only verifies that the known fields fit and then allows any remaining bytes, and clarified in the prose that
    trailing bytes should be treated as opaque future data.
### Tradeoffs
    None; note just instructs callers to tolerate extra data.
### Benefit
    Implementations can now accept future versions of the Marmot Group Data extension without failing validation, keeping groups interoperable as the
    format evolves.
### If Not Implemented
    Any newer extension version that appends fields would be rejected, causing clients to fail to join or process groups even when they could otherwise
    ignore the new data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now permits additional trailing data, improving compatibility with future format extensions while preserving support for all existing data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->