### PR TITLE
MIP-00: Use 64-char Nostr pubkey in KeyPackage examples

### DIFF
--- a/00.md
+++ b/00.md
@@ -38,7 +38,7 @@ KeyPackages are typically consumed when joining groups. To handle race condition
   "id": "abc123...",
   "kind": 443,
   "created_at": 1693876543,
-  "pubkey": "02a1633cafe37eeebe2b39b4ec5f3d74c35e61fa7e7e6b7b8c5f7c4f3b2a1b2c3d",
+  "pubkey": "f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100",
   "content": "0123456789abcdef...",
   "tags": [
     ["mls_protocol_version", "1.0"],
@@ -108,7 +108,7 @@ When using relay-based KeyPackage distribution, users publish a `kind: 10051` ev
   ],
   "content": "",
   "created_at": 1693876543,
-  "pubkey": "02a1633cafe37eeebe2b39b4ec5f3d74c35e61fa7e7e6b7b8c5f7c4f3b2a1b2c3d",
+  "pubkey": "f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100",
   "sig": "304502210..."
 }
 ```


### PR DESCRIPTION
### Warning
⚠️ Hallucinations may be present, or all encompassing. This is not reviewed by professional devs, or cryptographers. Proceed at own risk ⚠️. 

### Problem
  Both KeyPackage examples in MIP-00 show a 66-character compressed secp256k1 key, but Nostr uses 32-byte (64 hex) public keys. Copying the example leads implementers to serialize the wrong format, causing identity checks to fail.

###   Proposed Solution
  Update the sample JSON so the pubkey fields are 64-character hex strings, matching the canonical Nostr representation.

 ### Benefits

  - Keeps the documentation aligned with the actual protocol.
  - Prevents new implementations from copying an invalid key format.
  - Reduces interoperability bugs from mismatched identity encodings.

###  Tradeoffs
  None; only the illustrative example changes.

###  If Not Implemented
  Teams referencing the spec will continue using the compressed key from the example, leading to broken signatures and failed group membership validation.
