### PR TITLE
Clarify how pubkey should be encoded in credentials

### DIFF
--- a/00.md
+++ b/00.md
@@ -15,9 +15,11 @@ MLS `Credentials` link Nostr identities to group-specific signing keys, function
 When creating credentials, clients MUST:
 
 - **Use BasicCredential type**: The standard MLS credential format
-- **Set identity to Nostr pubkey**: Use the 32-byte hex-encoded public key of the user's Nostr identity
+- **Set identity to Nostr pubkey**: The identity field MUST contain the raw 32-byte public key (not hex-encoded). This is the binary representation of the user's Nostr public key.
 - **Keep identity immutable**: Never allow changes to the identity field
 - **Validate proposals**: Reject any `Proposal` or `Commit` that attempts to change identity fields
+
+**Note on encoding**: The identity field contains raw bytes. For a Nostr public key like `884704bd421671e01c13f854d2ce23ce2a5bfe9562f4f297ad2bc921ba30c3a6` (64 hex characters), the identity field should contain the 32 decoded bytes `[0x88, 0x47, 0x04, 0xbd, ...]`, not the 64 UTF-8 bytes of the hex string.
 
 ### Signing Keys
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MLS Credentials identity field requirements with clarification on the correct encoding format
  * Added example documentation showing proper formatting for the identity field configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->