### PR TITLE
Fix key_package event tag names to reflect what white noise is doing

### DIFF
--- a/00.md
+++ b/00.md
@@ -23,7 +23,7 @@ When creating credentials, clients MUST:
 
 ### Signing Keys
 
-Each credential includes a unique signing key (distinct from Nostr identity) that signs MLS messages and should rotate regularly for enhanced security. The curve used for the signing key is determined by the [MLS ciphersuite](https://www.rfc-editor.org/rfc/rfc9420.html#section-17.1) used by the client. All MLS ciphersuites are supported and are signaled to other users via the `ciphersuite` tag in KeyPackage events.
+Each credential includes a unique signing key (distinct from Nostr identity) that signs MLS messages and should rotate regularly for enhanced security. The curve used for the signing key is determined by the [MLS ciphersuite](https://www.rfc-editor.org/rfc/rfc9420.html#section-17.1) used by the client. All MLS ciphersuites are supported and are signaled to other users via the `mls_ciphersuite` tag in KeyPackage events.
 
 ## KeyPackage Events
 
@@ -44,8 +44,8 @@ KeyPackages are typically consumed when joining groups. To handle race condition
   "content": "0123456789abcdef...",
   "tags": [
     ["mls_protocol_version", "1.0"],
-    ["ciphersuite", "0x0001"],
-    ["extensions", "0x0001", "0x0002", "0x0003"],
+    ["mls_ciphersuite", "0x0001"],
+    ["mls_extensions", "0x0001", "0x0002", "0x0003"],
     ["client", "MyMLSClient", "event123...", "wss://relay.example.com"],
     ["relays", "wss://relay1.com", "wss://relay2.com"],
     ["-"]
@@ -59,8 +59,8 @@ KeyPackages are typically consumed when joining groups. To handle race condition
 **Required fields:**
 - **`content`**: Hex-encoded TLS-serialized `KeyPackageBundle` from your MLS implementation
 - **`mls_protocol_version`**: MLS protocol version - currently `1.0`
-- **`ciphersuite`**: MLS ciphersuite ID (see [MLS spec](https://www.rfc-editor.org/rfc/rfc9420.html#name-mls-cipher-suites))
-- **`extensions`**: Array of supported MLS extension IDs (see [MLS spec](https://www.rfc-editor.org/rfc/rfc9420.html#name-extensions))
+- **`mls_ciphersuite`**: MLS ciphersuite ID (see [MLS spec](https://www.rfc-editor.org/rfc/rfc9420.html#name-mls-cipher-suites))
+- **`mls_extensions`**: Array of supported MLS extension IDs (see [MLS spec](https://www.rfc-editor.org/rfc/rfc9420.html#name-extensions))
 - **`relays`**: Relay URLs where this KeyPackage is published (needed for later deletion when using relay distribution)
 
 **Optional fields:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+<!-- All notable changes to this project will be documented in this file. -->
+
+<!-- The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), -->
+<!-- and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). -->
+
+<!-- Template
+
+## Unreleased
+
+### Breaking changes
+
+### Changed
+
+### Added
+
+### Fixed
+
+### Removed
+
+### Deprecated
+
+-->
+
+## Unreleased
+
+### Breaking changes
+
+### Changed
+
+### Added
+
+### Fixed
+
+### Removed
+
+### Deprecated


### PR DESCRIPTION
In starting the work on `marmot-ts` we realized that the tag names here in Marmot are not correct to what we're doing already in whitenoise based on what is already implemented in [rust-nostr](https://github.com/rust-nostr/nostr/blob/d79245efe2c97424acc93da687d5f8077236a74b/crates/nostr/src/event/tag/kind.rs#L342). 

This corrects the tag names in the spec. 