### PR TITLE
Update link to last_resort extension to RFC

### DIFF
--- a/00.md
+++ b/00.md
@@ -31,7 +31,7 @@ KeyPackages function as public "invitation cards" enabling asynchronous group in
 
 ### KeyPackage Consumption and Reuse
 
-KeyPackages are typically consumed when joining groups. To handle race conditions where multiple invites use the same KeyPackage, use the [`last_resort`](https://docs.rs/openmls/latest/openmls/extensions/struct.LastResortExtension.html) extension for reusability. Clients MUST rotate signing keys quickly after using last resort KeyPackages and retain private keys for all groups.
+KeyPackages are typically consumed when joining groups. To handle race conditions where multiple invites use the same KeyPackage, use the [`last_resort`](https://datatracker.ietf.org/doc/html/draft-ietf-mls-extensions-03#section-4.2.5) extension for reusability. Clients MUST rotate signing keys quickly after using last resort KeyPackages and retain private keys for all groups.
 
 ### Example KeyPackage Event
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reference link in the KeyPackage Consumption and Reuse section to point to the latest IETF draft specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->