### PR TITLE
Update specification for mip04-v2 versioning and security

### DIFF
--- a/04.md
+++ b/04.md
@@ -37,7 +37,7 @@ This specification uses a versioning system to enable future evolution of the en
 ```
 exporter_secret = MLS-Exporter("nostr", "nostr", 32)
 file_key = HKDF-Expand(exporter_secret, "mip04-v2" || 0x00 || file_hash_bytes || 0x00 || mime_type_bytes || 0x00 || filename_bytes || 0x00 || "key", 32)
-nonce = Random(12)  // Cryptographically secure random 96-bit nonce
+nonce = Random(12)  // Cryptographically secure random 12 byte nonce
 ```
 
 The encryption key is derived deterministically from the MLS exporter secret, while the nonce is generated randomly for each encryption operation. The random nonce MUST be stored in the `imeta` tag's `n` field (hex-encoded) and provided during decryption.
@@ -72,7 +72,7 @@ The scheme label is version-specific and MUST match the version number (e.g., `"
 
 This ensures consistent key derivation across implementations regardless of input formatting.
 
-**Random Nonce Generation**: Version 2 uses cryptographically secure random nonce generation. Each encryption operation MUST generate a unique 96-bit (12-byte) nonce using a cryptographically secure random number generator. The nonce MUST be stored in the `imeta` tag and cannot be derived during decryption, ensuring true nonce uniqueness and preventing nonce reuse vulnerabilities.
+**Random Nonce Generation**: Version 2 uses cryptographically secure random nonce generation. Each encryption operation MUST generate a unique 12-byte nonce using a cryptographically secure random number generator. The nonce MUST be stored in the `imeta` tag and cannot be derived during decryption, ensuring true nonce uniqueness and preventing nonce reuse vulnerabilities.
 
 ### Encryption Algorithm
 
@@ -143,7 +143,7 @@ imeta url <blossom_url> m <mime_type> filename <filename> [dim <dimensions>] [bl
 | `v` | Encryption version number (currently "mip04-v2", deprecated: "mip04-v1") | Yes |
 
 **Version-Specific Fields**:
-- **Version 2 (`mip04-v2`)**: The `n` field is **required** and contains a randomly generated 96-bit (12-byte) nonce, hex-encoded as 24 characters.
+- **Version 2 (`mip04-v2`)**: The `n` field is **required** and contains a randomly generated 12-byte nonce, hex-encoded as 24 characters.
 - **Version 1 (`mip04-v1`)**: The `n` field is **not present** (nonce was derived deterministically). ⚠️ **Deprecated - MUST NOT be used for new media.**
 
 ### Integrity Verification


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Released Version 2 spec: uses cryptographically secure random nonces stored in metadata (n), updated AAD/domain separation with scheme labels (mip04-v2), and ChaCha20-Poly1305 guidance.
  * Marked Version 1 (mip04-v1) deprecated; added migration, rejection guidance, and MUST/SHOULD verification rules.
  * Clarified MIME canonicalization, field semantics, sending/receiving processing steps, and cross-version separation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->