### PR TITLE
Allow non-admin members to create self-update commits

### DIFF
--- a/01.md
+++ b/01.md
@@ -35,7 +35,7 @@ All groups MUST include these MLS extensions:
 Group modifications follow a two-step process:
 
 1. **Proposal**: Any member can propose changes (add/remove members, update settings)
-2. **Commit**: An admin commits to a set of proposals, making them official
+2. **Commit**: Changes are applied to the group state. Admins can commit any proposals, while non-admin members can only create self-update Commits (updating their own key material). See [MIP-03](03.md) for details.
 
 While these are MLS operations, `Commit` events must be published to Nostr relays so all members can see and process the changes.
 
@@ -170,7 +170,7 @@ When an admin updates the group image:
 
 **Creation**: When creating a new group, this extension MUST be populated with initial values and included in the group's required capabilities.
 
-**Updates**: Any field in this extension can be updated through MLS Proposal/Commit mechanisms. All updates require admin authorization. Before processing any Commit that modifies this extension, implementations MUST verify the committer is listed in the current `admin_pubkeys` array
+**Updates**: Any field in this extension can be updated through MLS Proposal/Commit mechanisms. All extension updates require admin authorization. Before processing any Commit that modifies this extension, implementations MUST verify the committer is listed in the current `admin_pubkeys` array. Note: Self-update Commits (where a member updates only their own key material) do not modify this extension and do not require admin authorization (see [MIP-03](03.md)).
 
 #### Version Handling
 

--- a/03.md
+++ b/03.md
@@ -52,7 +52,7 @@ Group Events use ephemeral keypairs and encrypted content to protect member iden
 Group modifications use a two-phase approach for safety and coordination:
 
 1. **Proposal Phase**: Members suggest changes
-2. **Commit Phase**: Admins approve and apply changes
+2. **Commit Phase**: Changes are applied (admins for most changes, any member for their own key updates)
 
 ### Proposal Messages
 
@@ -71,19 +71,28 @@ Group modifications use a two-phase approach for safety and coordination:
 
 ### Commit Messages
 
-**Who can commit**: Only group admins can create and send Commits
+**Who can commit**: Group admins can create and send any Commit. Non-admin members can ONLY create self-update Commits.
 
 **What commits do**:
 - Apply one or more pending proposals
 - Update the group's cryptographic state
 - Move the group to a new "epoch" (version)
 
-**Security requirements**:
-- Sender MUST be listed in `admin_pubkeys` (see [MIP-01](01.md))
-- Clients MUST verify admin status before processing any Commit
-- Invalid Commits from non-admins MUST be rejected
+**Self-update Commits**:
 
-> **Admin Control**: This design ensures only authorized admins can make actual changes to groups, while still allowing all members to participate in governance through proposals.
+A self-update Commit is one where the committer updates only their own key material (their LeafNode). This is essential for maintaining forward secrecy and post-compromise security (PCS), as members need to periodically rotate their signing keys.
+
+- Any member (admin or non-admin) MAY create a self-update Commit
+- Self-update Commits MUST contain only an Update proposal for the committer's own LeafNode
+- Self-update Commits MUST NOT include any other proposals (Add, Remove, GroupContextExtensions, etc.)
+
+**Security requirements**:
+- For self-update Commits: Clients MUST verify the Commit contains ONLY an Update proposal for the sender's own LeafNode
+- For all other Commits: Sender MUST be listed in `admin_pubkeys` (see [MIP-01](01.md))
+- Clients MUST verify admin status before processing any non-self-update Commit
+- Invalid Commits from non-admins (other than valid self-updates) MUST be rejected
+
+> **Admin Control**: This design ensures only authorized admins can make structural changes to groups (membership, settings), while allowing all members to maintain their own key hygiene through self-updates and participate in governance through proposals.
 
 ### Commit Message Race Conditions
 
@@ -151,13 +160,14 @@ This approach provides the best of both worlds:
 
 1. **Group Events** (`kind: 445`): Encrypted container for all group communication
 2. **Proposal Messages**: Member-initiated suggestions for group changes
-3. **Commit Messages**: Admin-authorized group state changes
+3. **Commit Messages**: Admin-authorized group state changes (except self-updates, which any member can perform)
 4. **Application Messages**: Regular content using Nostr event formats
 
 ### Implementation Requirements
 
 **MUST implement**:
-- Admin verification for all Commit messages with race condition handling
+- Admin verification for non-self-update Commit messages with race condition handling
+- Self-update Commit validation (must contain only sender's own Update proposal)
 - Key generation from `exporter_secret` with NIP-44 encryption
 - Identity verification for inner events (unsigned to prevent leaks)
 - Ephemeral keypairs (never reuse) for privacy protection

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ When working on protocol specifications, ensure these are always addressed:
 2. **Commit/Welcome Ordering**: Commits MUST be confirmed before sending Welcome events
 3. **Ephemeral Keypair Uniqueness**: Fresh keypair for EVERY kind: 445 event
 4. **Unsigned Inner Events**: Inner events MUST NOT be signed (prevents leak publication)
-5. **Admin Authorization**: Commits MUST verify sender is in admin_pubkeys array
+5. **Admin Authorization**: Non-self-update Commits MUST verify sender is in admin_pubkeys array (self-update Commits are allowed from any member)
 6. **TLS Serialization**: Exact TLS presentation language format required
 
 ## Code Style & Conventions


### PR DESCRIPTION
## Summary

- Non-admin members can now create self-update Commits to rotate their own key material without admin authorization
- Self-update Commits must contain ONLY an Update proposal for the sender's own LeafNode
- All other Commits (membership changes, settings, extension updates) still require admin authorization
- This enables all members to maintain forward secrecy and post-compromise security through regular key rotation