### PR TITLE
Add exception for initial group creation commit not being sent to relays

### DIFF
--- a/03.md
+++ b/03.md
@@ -94,6 +94,10 @@ Clients sending Commits MUST:
 2. **Wait for acknowledgment**: Don't apply the Commit locally until at least one relay confirms receipt
 3. **Then apply locally**: Only then update your own group state
 
+**Exception - Initial Group Creation**: The very first Commit that creates a group MUST NOT be sent to relays. This initial Commit establishes epoch 0 and exists only locally until members are invited. Sending it would unnecessarily expose metadata about group creation timing and the creating admin's activity. The first Commit that gets published to relays is the one that adds the first member.
+
+> **Note**: This exception intentionally departs from the MLS specification's general recommendation to confirm all commits before applying them locally. In a traditional MLS deployment with a central delivery service, confirming commits prevents state divergence. However, for the initial group creation in Marmot, there are no other members who could create a conflicting state, and publishing the creation commit would leak unnecessary metadata to relays. Privacy benefits outweigh the coordination guarantees that relay confirmation provides for subsequent commits.
+
 When receiving multiple Commits for the same epoch, clients MUST apply exactly one using this priority:
 1. **Timestamp priority**: Choose the Commit with the earliest `created_at` timestamp
 2. **ID tiebreaker**: If timestamps are identical, choose the Commit with the lexicographically smallest `id`

--- a/data_flows.md
+++ b/data_flows.md
@@ -125,6 +125,8 @@ sequenceDiagram
 - `nostr_group_id` is public-ish (observable by relays)
 - Extension is cryptographically authenticated
 - No data leaves client during creation
+- Initial creation Commit is applied locally only (never sent to relays)
+- This intentionally departs from MLS spec to preserve privacy—no coordination needed when creator is the only member
 
 ---
 
@@ -358,6 +360,8 @@ sequenceDiagram
 5. Members verify admin status
 6. Members process and advance epoch
 7. Race conditions handled by timestamp/ID priority
+
+**Exception - Initial Group Creation**: The very first Commit that creates a group MUST NOT be sent to relays. This initial Commit is applied locally only, establishing epoch 0. It exists purely on the creating admin's device until the first member invitation. This preserves privacy by not exposing group creation metadata to relays. The first Commit published to relays is the one adding the first member. This intentionally departs from MLS spec recommendations—since no other members exist yet, there's no risk of state divergence, and privacy benefits outweigh coordination guarantees.
 
 **Security Notes:**
 - ✅ Admin verification REQUIRED


### PR DESCRIPTION
## Summary

- Documents that the initial group creation commit MUST NOT be sent to relays
- Clarifies this is an intentional departure from MLS spec recommendations for privacy reasons
- Updates both MIP-03 and data_flows.md with consistent messaging

## Rationale

When a group is first created, there are no other members who could create a conflicting state. Publishing the creation commit would unnecessarily expose metadata about:
- Group creation timing
- The creating admin's activity patterns

Since no coordination is needed when the creator is the only member, the privacy benefits outweigh the coordination guarantees that relay confirmation provides for subsequent commits.

## Changes

**03.md (MIP-03 Group Messages)**:
- Added exception paragraph after the "Clients sending Commits MUST" requirements
- Added blockquote explaining the intentional departure from MLS spec

**data_flows.md**:
- Added security notes in the Group Creation Flow section
- Added exception paragraph in the Commit Message Data Flow section

## Test plan

- [ ] Review that the exception is clearly documented in both locations
- [ ] Verify the rationale for departing from MLS spec is clear
- [ ] Check consistency between MIP-03 and data_flows.md explanations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated group creation and commit flow documentation to clarify initial commit handling behavior
  * Enhanced data flow documentation with explicit guidance on privacy considerations during group creation
  * Clarified design decisions affecting how groups are initialized within the system

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->