### PR TITLE
Document state fork risk for Commit/Welcome timing

### DIFF
--- a/02.md
+++ b/02.md
@@ -23,6 +23,22 @@ Clients creating Welcome Events MUST:
 
 This sequencing prevents race conditions where a new member receives a Welcome for a group state that hasn't been finalized yet.
 
+> #### CRITICAL: State Fork Prevention
+>
+> **This timing requirement applies to ALL member additions after initial group creation.** When adding members to an existing group, the Commit message MUST be accepted by relays BEFORE sending the Welcome message.
+>
+> **Why this matters**: The Welcome message contains the group state at a specific epoch. If the Welcome is delivered before the Commit reaches existing members, a **state fork** occurs:
+>
+> - The new member activates at epoch N+1 (from the Welcome)
+> - Existing members remain at epoch N (haven't received the Commit yet)
+> - Messages sent by the new member cannot be decrypted by existing members
+> - Messages sent by existing members cannot be decrypted by the new member
+> - The group state diverges, requiring manual recovery
+>
+> **This is not a theoretical concern**—distributed relay networks can deliver messages out of order. The only reliable prevention is waiting for relay confirmation of the Commit before sending the Welcome.
+>
+> **Note**: Initial group creation (single-member group with no prior epochs) does not require this wait because there are no existing members who could have a conflicting state.
+
 ## Privacy and Security
 
 Welcome Events use [NIP-59](https://github.com/nostr-protocol/nips/blob/master/59.md) gift-wrapping for privacy and unlinkability.

--- a/03.md
+++ b/03.md
@@ -102,6 +102,13 @@ Clients sending Commits MUST:
 1. **Send the Group Event**: Publish the Commit as a Group Event to relays
 2. **Wait for acknowledgment**: Don't apply the Commit locally until at least one relay confirms receipt
 3. **Then apply locally**: Only then update your own group state
+4. **Then send any associated Welcomes**: If this Commit adds new members, Welcome messages may only be sent AFTER relay acknowledgment (see [MIP-02](02.md) Timing Requirements)
+
+> #### State Fork Risk for Member Additions
+>
+> When a Commit adds new members to an existing group, the timing of Welcome message delivery is critical. If a Welcome is sent before the Commit is confirmed by relays, the new member may activate into an epoch that existing members haven't reached yet, causing a **state fork** where messages cannot be decrypted across the fork boundary.
+>
+> See [MIP-02](02.md) for the complete timing requirements and state fork prevention guidance.
 
 **Exception - Initial Group Creation**: The very first Commit that creates a group MUST NOT be sent to relays. This initial Commit establishes epoch 0 and exists only locally until members are invited. Sending it would unnecessarily expose metadata about group creation timing and the creating admin's activity. The first Commit that gets published to relays is the one that adds the first member.
 

--- a/data_flows.md
+++ b/data_flows.md
@@ -195,6 +195,22 @@ sequenceDiagram
 - ✅ Welcome unsigned (cannot be republished)
 - ⚠️ Relay can observe timing correlation
 
+> ### State Fork Prevention
+>
+> **Why Commit confirmation before Welcome is CRITICAL:**
+>
+> The Welcome message contains the group state at epoch N+1 (the epoch created by the Commit). If the Welcome reaches the new member before the Commit reaches existing members:
+>
+> 1. New member activates at epoch N+1
+> 2. Existing members are still at epoch N
+> 3. **State fork occurs**: the new member and existing members have incompatible group states
+> 4. Messages fail to decrypt across the fork boundary
+> 5. Manual recovery (re-invitation or new group creation) is required
+>
+> Distributed relay networks can and do deliver messages out of order. The admin MUST wait for at least one relay to confirm receipt of the Commit before sending the Welcome. This is the only reliable way to prevent state forks.
+>
+> **Note**: This requirement applies to all member additions to existing groups. Initial group creation (where there are no existing members) does not have this constraint.
+
 ---
 
 ## Group Messaging Flow


### PR DESCRIPTION
## Summary

- Adds comprehensive documentation across multiple spec files to make the state fork risk clear to implementers
- Emphasizes that Commit messages must be accepted by relays BEFORE sending Welcome messages for member additions to existing groups
- Explains the consequences of violating this requirement (group state divergence, decryption failures, manual recovery required)

Addresses feedback from https://github.com/marmot-protocol/mdk/issues/73#issuecomment-3728423288

## Changes

### MIP-02 (Welcome Events)
- Added "CRITICAL: State Fork Prevention" callout explaining why this timing requirement exists
- Documents the exact failure mode (epoch mismatch between new and existing members)
- Notes the exception for initial group creation

### MIP-03 (Group Messages)
- Added step 4 to Commit flow: Welcome messages may only be sent AFTER relay acknowledgment
- Added "State Fork Risk for Member Additions" callout with cross-reference to MIP-02

### data_flows.md (Member Invitation Flow)
- Added "State Fork Prevention" section explaining the exact sequence of events that causes a fork
- Documents that manual recovery is required when state forks occur

### threat_model.md
- **T.7.4**: Renamed to "State Fork Vulnerability", expanded with detailed impact, prerequisites, and why library-level prevention isn't feasible
- **Section 3.0.2**: Added explicit state fork consequences and exception for initial group creation
- **Section 3.1.3**: Expanded implementation pitfall with state fork consequences and testing recommendations

## Test plan

- [ ] Review documentation changes for clarity and accuracy
- [ ] Verify cross-references between MIP-02, MIP-03, data_flows.md, and threat_model.md are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified state fork prevention requirements for member addition workflows.
  * Added guidance on Commit relay confirmation timing before Welcome message delivery.
  * Introduced new requirements for ephemeral keypair uniqueness and unsigned event handling.
  * Expanded threat model with state fork scenarios and recovery guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->