### PR TITLE
feat(MIP-00): add required 'i' tag for KeyPackageRef indexing

### DIFF
--- a/00.md
+++ b/00.md
@@ -47,6 +47,7 @@ KeyPackages are typically consumed when joining groups. To handle race condition
     ["mls_ciphersuite", "0x0001"],
     ["mls_extensions", "0xf2ee", "0x000a"],
     ["encoding", "base64"],
+    ["i", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"],
     ["client", "MyMLSClient"],
     ["relays", "wss://relay1.com", "wss://relay2.com"],
     ["-"]
@@ -69,11 +70,70 @@ The `mls_extensions` tag includes marmot_group_data (`0xf2ee`) and last_resort (
 - **`mls_protocol_version`**: MLS protocol version - currently `1.0`
 - **`mls_ciphersuite`**: MLS ciphersuite ID (see [MLS spec](https://www.rfc-editor.org/rfc/rfc9420.html#name-mls-cipher-suites))
 - **`mls_extensions`**: Array of supported non-default MLS extension IDs (see [MLS spec](https://www.rfc-editor.org/rfc/rfc9420.html#name-extensions)). Default extensions MUST NOT be listed. This signals **individual client capabilities** via `LeafNode.capabilities` in KeyPackages. Marmot implementations MUST include the `0xf2ee` extension for marmot_group_data and the `0x000a` extension for last_resort.
+- **`i`**: Hex-encoded `KeyPackageRef` for efficient relay queries (see [KeyPackageRef Tag](#keypackageref-tag) below)
 - **`relays`**: Relay URLs where this KeyPackage is published (needed for later deletion when using relay distribution)
 
 **Optional fields:**
 - **`client`**: Client name to help with UX when users can't access signing keys (may be omitted for privacy). Format: `["client", "<name>"]`
 - **`-`**: Ensures only the author can publish this event (see [NIP-70](https://github.com/nostr-protocol/nips/blob/master/70.md))
+
+### KeyPackageRef Tag
+
+The `i` tag contains the hex-encoded `KeyPackageRef`, enabling efficient relay queries for specific KeyPackages.
+
+#### Background
+
+According to [RFC 9420 Section 5.2](https://www.rfc-editor.org/rfc/rfc9420.html#section-5.2), `KeyPackageRef` is computed as:
+
+```
+MakeKeyPackageRef(value) = RefHash("MLS 1.0 KeyPackage Reference", value)
+```
+
+Where `value` is the TLS-serialized KeyPackage and the hash function is determined by the ciphersuite.
+
+#### Why This Tag Is Required
+
+Without the `i` tag, finding a KeyPackage by its `KeyPackageRef` requires:
+1. Downloading all KeyPackage events from relays
+2. Decoding each event's content
+3. Computing the `KeyPackageRef` for each
+4. Comparing against the target
+
+This is computationally expensive, especially when processing Welcome messages that reference KeyPackages via `KeyPackageRef` (see [MIP-02](02.md)).
+
+#### Computing the Tag Value
+
+```typescript
+// Compute KeyPackageRef using your MLS implementation
+const keyPackageRef = await makeKeyPackageRef(keyPackage, ciphersuiteImpl.hash);
+
+// Hex-encode for the tag
+const tagValue = bytesToHex(keyPackageRef);
+
+// Add to event tags
+tags.push(["i", tagValue]);
+```
+
+#### Querying by KeyPackageRef
+
+Clients can efficiently query relays:
+
+```typescript
+const filter = {
+  kinds: [443],
+  "#i": ["a1b2c3d4e5f6..."]  // hex-encoded KeyPackageRef
+};
+```
+
+#### Validation
+
+When receiving KeyPackage events with an `i` tag, implementations SHOULD validate that the tag value matches the computed `KeyPackageRef` from the decoded content. Events with mismatched values SHOULD be treated as invalid.
+
+#### Backward Compatibility
+
+- **New events**: MUST include the `i` tag
+- **Existing events**: May not have this tag; implementations MUST continue to support computing `KeyPackageRef` from event content when the tag is absent
+- **Migration**: Implementations MAY re-publish existing KeyPackages with the `i` tag added
 
 ### KeyPackage Lifecycle Management
 


### PR DESCRIPTION
## Summary

Implements the specification change requested in #30 — adds an indexable `i` tag to KeyPackage events (kind 443) containing the hex-encoded `KeyPackageRef`.

## Problem

Currently, finding a KeyPackage by its `KeyPackageRef` requires downloading all KeyPackage events, decoding each, and computing the `KeyPackageRef` for comparison. This is bandwidth-intensive and computationally expensive, especially when processing Welcome messages.

## Solution

Add a required `i` tag containing the hex-encoded `KeyPackageRef` (as computed per RFC 9420 Section 5.2). This enables efficient relay queries:

```typescript
{ kinds: [443], "#i": ["a1b2c3d4e5f6..."] }
```

## Changes

- Added `i` tag to required fields documentation
- Added new "KeyPackageRef Tag" section with:
  - Background on `KeyPackageRef` computation
  - Rationale for why the tag is required
  - Code example for computing the tag value
  - Query example
  - Validation requirements
  - Backward compatibility notes
- Updated example KeyPackage event to include the tag

## Backward Compatibility

- New events MUST include the `i` tag
- Existing events without the tag remain valid; implementations MUST continue computing `KeyPackageRef` from content when tag is absent
- Implementations MAY re-publish existing KeyPackages with the tag added

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the new KeyPackageRef tag in KeyPackage events, including computation and encoding guidance.
  * Provided example queries and validation steps for using the tag.
  * Documented backward compatibility rules for new and existing events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->