### PR TITLE
Add MIP 06: Group Voice and Video Calling

### DIFF
--- a/06.md
+++ b/06.md
@@ -1,0 +1,1512 @@
+# MIP-06
+
+## Group Voice & Video Calling
+
+`draft` `optional`
+
+**Depends on**: MIP-00 (Credentials & Key Packages), MIP-01 (Group Construct=
+ion), MIP-03 (Group Messages), MIP-05 (Push Notifications)
+
+This document defines a privacy-preserving approach to real-time voice and v=
+ideo calling within Marmot groups using WebRTC, with end-to-end encryption k=
+eyed from the MLS group state and a tiered media topology for scalability fr=
+om two-person calls to arena-scale broadcasts.
+
+## Overview
+
+Users expect real-time voice and video calls in their messaging applications=
+. In many centralized systems, the call server terminates encryption and has=
+ full access to media streams. Some centralized services (notably Signal) ha=
+ve adopted end-to-end encrypted calling using SFrame, but their key distribu=
+tion still depends on a trusted server to mediate. Marmot's architecture mak=
+es a different approach possible: since all callers are already members of a=
+n MLS group with shared cryptographic state, call encryption keys can be der=
+ived directly from the group's existing key material without any server-medi=
+ated key exchange, and call signaling can travel through the existing MLS-en=
+crypted channel without any server seeing its contents.
+
+This specification provides a system where:
+
+1. **Media encryption keys** are derived from the MLS epoch's exporter secre=
+t, giving every call participant the same symmetric keying material without a=
+ny additional key exchange
+2. **SFrame end-to-end encryption** (RFC 9605) protects audio and video fram=
+es so that Selective Forwarding Units (SFUs) route media without decrypting i=
+t
+3. **Call signaling** travels as MLS Application Messages through the existi=
+ng Marmot group channel, authenticated by MLS and encrypted end-to-end
+4. **Tiered media topology** scales from peer-to-peer mesh (2=E2=80=934 part=
+icipants) through single SFU (5=E2=80=93100 participants) to cascaded SFU fe=
+derations (100+ participants)
+5. **MIP-05 push notifications** ring offline devices using the existing gif=
+t-wrapped notification mechanism
+6. **User control** allows participants to join voice-only, mute/unmute audi=
+o and video, disable video, decline calls, leave mid-call, end the call for a=
+ll participants, hold and resume, start and stop screen sharing, request spe=
+aker focus, switch devices, and select enhanced privacy mode
+
+## Architecture
+
+### Components
+
+1. **Client Application**: Marmot-compatible app with a WebRTC stack that ca=
+ptures, encodes, encrypts (via SFrame), and transmits audio/video =E2=80=94 a=
+nd receives, decrypts, decodes, and renders incoming streams
+2. **MLS Group**: The existing Marmot group provides identity, authenticatio=
+n, and keying material for the call
+3. **Nostr Relays**: Carry call signaling events (offers, answers, ICE candi=
+dates, call state) as MLS Application Messages inside `kind: 445` Group Even=
+ts
+4. **Selective Forwarding Unit (SFU)**: An optional media router that forwar=
+ds encrypted media packets without decrypting them. Used for calls with 5+ p=
+articipants. Treated as untrusted infrastructure =E2=80=94 it never holds co=
+ntent keys
+5. **TURN Server**: Standard WebRTC relay for NAT traversal. Carries DTLS-SR=
+TP traffic that also carries SFrame-encrypted payloads, so TURN operators se=
+e only opaque ciphertext
+6. **Apple/Google Push Services**: Ring offline devices via MIP-05
+
+### Privacy Properties
+
+The system is designed so that media content is accessible only to MLS group=
+ members who have joined the call. This table is the authoritative reference=
+ for information flow in MIP-06. The Security Considerations section referen=
+ces this table and covers residual risks and attack trees.
+
+| Actor | Learns | Cannot Learn |
+|-------|--------|-------------|
+| **SFU** | Timing, bandwidth, packet counts. IP addresses of connected part=
+icipants. Active SSRCs. SFrame header metadata (KID reveals sender leaf inde=
+x; CTR reveals frame sequence). Encrypted packet sizes (enables inference of=
+ video resolution changes, speech activity from VBR packet variance). RTP he=
+ader extensions (Dependency Descriptor SVC layer metadata, `ssrc-audio-level=
+`) | Media content (audio/video). Participant Nostr identities (sees only ep=
+hemeral DTLS identities and SFrame KIDs mapping to MLS leaf indices unknown t=
+o SFU). MLS group identity. Message history. Call signaling content |
+| **TURN server** | IP addresses of connected participants. Encrypted packet=
+ sizes and timing | Media content. Participant identities. Which SFU traffic=
+ is destined for (opaque UDP relay) |
+| **Nostr relays** | Timing and size of signaling events (encrypted inside M=
+LS Application Messages). Sender IP addresses | Signaling content (offers, a=
+nswers, ICE candidates). Participant identities (events are MLS-encrypted). C=
+all metadata (who called whom, call duration) |
+| **Apple/Google** | A push notification occurred (per MIP-05 properties) | W=
+hether the notification is for a call vs. a message |
+| **MLS group members NOT on call** | That a call is occurring (they see sig=
+naling events). They possess the MLS exporter secret and SFrame base key | M=
+edia content (they lack the WebRTC session). However: all group members *cou=
+ld* derive the media encryption keys; only participants who complete WebRTC s=
+ession establishment actually receive media packets. This matches the MLS tr=
+ust boundary =E2=80=94 see Design Rationale |
+| **All actors** | (Critical privacy property) No new long-lived identifiers=
+ are introduced. Call signaling uses MLS channel with ephemeral sender keys (=
+MIP-03). WebRTC connections use ephemeral DTLS certificates. SFrame keys are=
+ derived per-epoch and rotate with MLS state changes | =E2=80=94 |
+
+### Design Rationale: Group Members as Trust Boundary
+
+The decision to derive call keys from the existing MLS group (rather than cr=
+eating a separate MLS subgroup per call) is deliberate. All group members ca=
+n *theoretically* derive the SFrame base key because they share the MLS epoc=
+h state. But only participants who join the WebRTC session (authenticate wit=
+h the SFU and complete ICE/DTLS) actually receive media packets. This means a=
+ non-participating group member would need to independently connect to the S=
+FU with the derived auth token to eavesdrop =E2=80=94 an active attack that i=
+s equivalent to silently joining the call, which other participants can dete=
+ct in the call's signaling events.
+
+This tradeoff avoids the latency and complexity of creating a dedicated MLS s=
+ubgroup for every call (which would require Welcome messages, new epoch tran=
+sitions, and KeyPackage fetches before media could flow). If stronger isolat=
+ion is required, the call initiator MAY create a separate MLS group containi=
+ng only accepted participants and use that group's exporter for key derivati=
+on =E2=80=94 this is a client-level policy decision, not a protocol requirem=
+ent.
+
+## MLS-Derived Media Encryption
+
+### Key Derivation
+
+#### Specification
+
+```text
+call_base_key =3D MLS-Exporter(
+    label:   "marmot-call-v1",
+    context: call_id,
+    length:  32
+)
+
+sframe_base_key =3D HKDF-Expand(
+    PRK:  call_base_key,
+    info: "sframe" || media_type (1 byte) || sender_leaf_index (4 bytes, big=
+-endian),
+    L:    16
+)
+```
+
+Where `media_type` is: `0x00` =3D audio, `0x01` =3D video, `0x02` =3D screen=
+ share.
+
+> **Implementation Note =E2=80=94 HKDF-Expand vs HKDF-Extract**: The `call_b=
+ase_key` is already a pseudorandom key (it is the output of MLS-Exporter, wh=
+ich internally applies HKDF-Extract via `DeriveSecret` and `ExpandWithLabel`=
+). Implementations MUST use HKDF-Expand directly with `call_base_key` as the=
+ PRK. Do NOT apply HKDF-Extract to `call_base_key` before expanding. This is=
+ a common mistake when using library APIs that combine Extract+Expand into a=
+ single function call (e.g., Python's `hkdf.HKDF()`, Go's `hkdf.New()`, Rust=
+'s `Hkdf::new()`, Node.js `hkdf()` from the `futoin-hkdf` package). Use APIs=
+ that accept a raw PRK directly for the Expand step (e.g., Rust's `Hkdf::fro=
+m_prk()`, Python's `HKDFExpand()`, Node.js `crypto.createHmac()` manually, o=
+r the Web Crypto API's `importKey` + `deriveBits` with HKDF and empty salt).=
+ The test vectors in this document will NOT match if Extract is applied to `=
+call_base_key` before Expand. The same applies to the SFU auth token derivat=
+ion.
+
+The `sframe_base_key` is then processed by the SFrame key schedule (RFC 9605=
+ =C2=A74.4.1):
+
+```text
+sframe_secret =3D HKDF-Extract("", sframe_base_key)
+sframe_key    =3D HKDF-Expand(sframe_secret, "SFrame 1.0 Secret key" || KID_=
+8BE || CS, 16)
+sframe_salt   =3D HKDF-Expand(sframe_secret, "SFrame 1.0 Secret salt" || KID=
+_8BE || CS, 12)
+nonce         =3D XOR(sframe_salt, encode_big_endian(CTR, 12))
+ciphertext    =3D AES-128-GCM.Encrypt(sframe_key, nonce, sframe_header, plai=
+ntext_frame)
+```
+
+Where `KID_8BE` is the SFrame Key ID as 8 bytes big-endian and `CS` is the c=
+iphersuite identifier `0x0001` (AES_128_GCM_SHA256_128) as 2 bytes big-endia=
+n.
+
+> **Implementation Note =E2=80=94 SFrame Key Schedule Uses Extract**: In con=
+trast to the `sframe_base_key` derivation above, the SFrame key schedule (RFC=
+ 9605 =C2=A74.4.1) DOES begin with HKDF-Extract on `sframe_base_key`. This i=
+s correct because `sframe_base_key` is a 16-byte HKDF-Expand output that ben=
+efits from the Extract step to produce a full-length PRK. The two derivation=
+ steps intentionally use different HKDF patterns: Expand-only for the first (=
+because the input is already a PRK), Extract-then-Expand for the second (bec=
+ause the input is not).
+
+**Epoch transitions**: When the MLS epoch changes (member joins, leaves, or k=
+ey update), clients MUST derive new `call_base_key` from the new epoch and r=
+e-derive all SFrame keys. Senders MUST begin encrypting new frames with the u=
+pdated keys immediately. If a frame is currently being encoded when the epoc=
+h change is processed (e.g., a video keyframe, which takes longer to encode t=
+han a delta frame), it MUST be encrypted under the new epoch's keys, NOT the=
+ old epoch's keys. Receivers MUST retain the previous epoch's keys for 2 sec=
+onds to decrypt in-flight frames. After the grace period, old keys MUST be s=
+ecurely discarded (zeroed from memory).
+
+#### Design Rationale
+
+The MLS-Exporter function (RFC 9420 =C2=A78.5) is specifically designed for d=
+eriving application-specific secrets without exposing the underlying tree se=
+crets. Internally it computes `ExpandWithLabel(DeriveSecret(exporter_secret,=
+ label), "exported", Hash(context), length)`, which ensures cryptographic do=
+main separation from MLS's internal key schedule.
+
+The `call_id` in the context field binds keys to a specific call session. Wi=
+thout this, concurrent calls in the same group would share keys =E2=80=94 a c=
+atastrophic nonce reuse if both calls have senders with the same leaf index.=
+ The per-sender derivation (via `sender_leaf_index` in the HKDF-Expand info)=
+ ensures that compromising one sender's SFrame state does not expose other s=
+enders' keys. The `media_type` field prevents nonce collision between audio a=
+nd video streams that have independent frame counters.
+
+The 2-second epoch key grace period is sized to exceed one full RTT plus typ=
+ical jitter buffer depth on congested networks, ensuring in-flight frames en=
+crypted under the old epoch can still be decrypted after the transition.
+
+### SFrame Encryption
+
+#### Specification
+
+Media frames are encrypted using SFrame (RFC 9605) applied via the W3C `RTCR=
+tpScriptTransform` API (WebRTC Encoded Transforms):
+
+```text
+Capture =E2=86=92 Encode =E2=86=92 [SFrame Encrypt] =E2=86=92 Packetize =E2=86=
+=92 SRTP =E2=86=92 Network
+Network =E2=86=92 SRTP =E2=86=92 Depacketize =E2=86=92 [SFrame Decrypt] =E2=86=
+=92 Decode =E2=86=92 Render
+```
+
+**Cipher suite**: `AES_128_GCM_SHA256_128` (ciphersuite 0x0001). Nk=3D16, Nn=
+=3D12, Nt=3D16, Nh=3D32.
+
+**Counter (CTR)**: Monotonically increasing per sender per media type. MUST N=
+OT be reused within a key epoch. MUST be reset to 0 when the epoch changes.
+
+**SFrame header format** (RFC 9605 =C2=A74.3):
+```text
+Config byte: |X|  K  |Y|  C  |
+              1   3    1   3   bits
+
+X =3D 0: K is the Key ID (0-7)
+X =3D 1: K is the byte-length of extended Key ID, minus 1
+Y =3D 0: C is the Counter (0-7)
+Y =3D 1: C is the byte-length of extended Counter, minus 1
+```
+
+Total SFrame overhead per frame: header (2=E2=80=935 bytes) + AES-GCM tag (1=
+6 bytes) =3D 18=E2=80=9321 bytes.
+
+**Encryption scope**:
+- Audio frames: MUST be SFrame-encrypted
+- Video frames: MUST be SFrame-encrypted. The Dependency Descriptor RTP head=
+er extension carries SVC layer metadata outside the encrypted payload
+- Screen share frames: MUST be SFrame-encrypted using media_type 0x02
+- Data channel messages: SHOULD be sent as MLS Application Messages (kind 44=
+5) rather than WebRTC data channels
+
+#### Design Rationale
+
+SFrame was chosen over hop-by-hop SRTP because standard DTLS-SRTP terminates=
+ at each hop =E2=80=94 the SFU must decrypt and re-encrypt when forwarding, g=
+aining full access to plaintext media. SFrame encrypts at the frame level ab=
+ove SRTP, so the SFU forwards opaque ciphertext while still examining RTP he=
+aders and header extensions for bandwidth adaptation and layer selection.
+
+SVC is preferred over simulcast for SFU-routed calls because SVC uses a sing=
+le SSRC and encryption context. Simulcast requires independent SFrame encryp=
+tion per quality layer, each with its own CTR sequence =E2=80=94 tripling ke=
+y management complexity. With SVC, the Dependency Descriptor RTP header exte=
+nsion (unencrypted, in the RTP header) carries layer metadata, allowing the S=
+FU to extract temporal/spatial layers from a single encrypted stream.
+
+`AES_128_GCM_SHA256_128` was chosen to match Marmot's MLS ciphersuite (MLS_1=
+28_DHKEMX25519_AES128GCM_SHA256_Ed25519), keeping cryptographic primitives c=
+onsistent across the protocol stack.
+
+### KID Structure
+
+#### Specification
+
+The SFrame Key ID encodes epoch, sender identity, and media type:
+
+```text
+KID =3D (media_type << (S + E)) | (sender_leaf_index << E) | (epoch_counter %=
+ (1 << E))
+
+E =3D 4 (epoch bits, supporting 16 simultaneous epochs during transitions)
+S =3D negotiated via sframe_bits tag in kind 450 (default: 6, supporting up t=
+o 64 members)
+```
+
+**Receiver parsing**:
+```text
+epoch_counter    =3D KID & ((1 << E) - 1)
+sender_leaf_index =3D (KID >> E) & ((1 << S) - 1)
+media_type       =3D KID >> (S + E)
+```
+
+If the parsed `epoch_counter` does not match any currently held epoch, the f=
+rame MUST be dropped.
+
+**KID examples** (E=3D4, S=3D6):
+
+| Sender | Media | Epoch | KID (decimal) | KID (hex) |
+|--------|-------|-------|---------------|-----------|
+| leaf 0 | audio | 0 | 0 | 0x0000 |
+| leaf 3 | audio | 0 | 48 | 0x0030 |
+| leaf 3 | audio | 14 | 62 | 0x003e |
+| leaf 3 | video | 14 | 1086 | 0x043e |
+| leaf 3 | screen | 14 | 2110 | 0x083e |
+| leaf 63 | audio | 15 | 1023 | 0x03ff |
+
+#### Design Rationale
+
+Encoding epoch, sender, and media type into KID eliminates the need for sepa=
+rate signaling to communicate which key a given frame was encrypted under. T=
+he receiver extracts all three fields from the KID and immediately selects t=
+he correct key. The 4-bit epoch field allows 16 simultaneous epoch key sets,=
+ which is generous given that epoch transitions during active calls (member j=
+oin/leave) complete within seconds and old keys are retained for only 2 seco=
+nds.
+
+## Call Signaling
+
+### Specification
+
+All call signaling is carried as MLS Application Messages inside `kind: 445`=
+ Group Events per MIP-03. Inner application messages use unsigned Nostr even=
+t kinds 450=E2=80=93454.
+
+#### Event Kind Summary
+
+| Kind | Name | Direction | Purpose |
+|------|------|-----------|---------|
+| 450 | Call Initiation | Caller =E2=86=92 Group | Start a new call |
+| 451 | Call Answer | Callee =E2=86=92 Group | Accept, decline, or report bu=
+sy |
+| 452 | WebRTC Session Description | Peer =E2=86=94 Peer | SDP offer/answer e=
+xchange |
+| 453 | ICE Candidate | Peer =E2=86=94 Peer | Trickle ICE candidate exchange=
+ |
+| 454 | Call State Update | Participant =E2=86=92 Group | Mute, leave, end, s=
+creen share, topology change, etc. |
+
+All events MUST remain unsigned (no `sig` field) per MIP-03 security require=
+ments.
+
+#### Call Initiation (kind 450)
+
+```json
+{
+    "kind": 450,
+    "created_at": 1693876700,
+    "pubkey": "<caller_nostr_pubkey>",
+    "content": "",
+    "tags": [
+        ["call_id", "<32-byte-random-hex>"],
+        ["call_type", "audio|video"],
+        ["sframe_bits", "6"],
+        ["sfu", "<sfu_pubkey_hex>", "<sfu_websocket_url>"],
+        ["turn", "<turn_uri>", "<turn_username>", "<turn_credential>"],
+        ["codec", "audio/opus", "video/av1"],
+        ["privacy", "standard|enhanced"]
+    ]
+}
+```
+
+**Tag definitions**:
+- **call_id**: 32-byte random identifier (CSPRNG). Used as `context` in MLS-=
+Exporter key derivation. MUST be unique per call; clients MUST reject duplic=
+ates
+- **call_type**: `"audio"` or `"video"`. Participants MAY override locally
+- **sframe_bits**: Value of S for KID structure. Default `"6"`. MUST be `>=3D=
+ ceil(log2(current_group_size))` with minimum 4
+- **sfu**: SFU operator pubkey (hex) and WebSocket URL. Zero tags =E2=86=92 m=
+esh. One tag =E2=86=92 single SFU. Multiple tags =E2=86=92 cascaded federati=
+on
+- **turn**: TURN URI, optional time-limited username, and credential. Creden=
+tials SHOULD be short-lived (TURN REST API / HMAC-SHA1)
+- **codec**: Preferred audio and video codecs. Default: `audio/opus`, `video=
+/vp8`
+- **privacy**: `"standard"` (default) or `"enhanced"`. See Privacy Enhanceme=
+nts
+
+Upon sending kind 450, the caller MUST simultaneously trigger MIP-05 push no=
+tifications to ring offline devices.
+
+#### Call Answer (kind 451)
+
+```json
+{
+    "kind": 451,
+    "created_at": 1693876710,
+    "pubkey": "<callee_nostr_pubkey>",
+    "content": "",
+    "tags": [
+        ["call_id", "<call_id_from_450>"],
+        ["status", "accept|decline|busy"],
+        ["reason", "<optional_reason>"]
+    ]
+}
+```
+
+A `"decline"` or `"busy"` response is informational =E2=80=94 it tells the c=
+aller's UI to stop ringing for that participant and does not affect the call=
+ itself. When any of a user's devices sends `"decline"` or `"busy"`, all oth=
+er devices belonging to the same user (identified by shared Nostr pubkey per=
+ MIP-00) MUST also stop ringing. See Multi-Device Call Handling.
+
+The `reason` tag is OPTIONAL. Defined reason values include `"unsupported_to=
+pology"`, `"unsupported_version"`, `"user_declined"`, and `"device_busy"`. U=
+nknown reason values MUST be ignored by receivers.
+
+#### WebRTC Session Description (kind 452)
+
+```json
+{
+    "kind": 452,
+    "created_at": 1693876720,
+    "pubkey": "<sender_nostr_pubkey>",
+    "content": "<sdp_string>",
+    "tags": [
+        ["call_id", "<call_id>"],
+        ["sdp_type", "offer|answer"],
+        ["target_leaf", "<leaf_index>"]
+    ]
+}
+```
+
+SDP MUST be sanitized before sending. Specifically: remove `a=3Dcandidate` l=
+ines containing RFC 1918 private IP addresses (192.168.x.x, 10.x.x.x, 172.16=
+=E2=80=9331.x.x) because these reveal the sender's local network topology to=
+ other participants. Replace the hostname in the SDP `o=3D` (origin) line wi=
+th a random string because many devices populate this with the machine's hos=
+tname (e.g., "Alice-MacBook-Pro"), leaking identifying information. SDP MUST=
+ use Unified Plan format (one `m=3D` section per audio/video track, as oppos=
+ed to the deprecated Plan B which bundled multiple tracks into a single sect=
+ion) and MUST include `a=3Dgroup:BUNDLE` to multiplex all media streams over=
+ a single transport connection, reducing ICE negotiation and port usage. In S=
+FU mode, `target_leaf` is set to `"sfu"` rather than a numeric leaf index, s=
+ince the SDP negotiation is between the client and the SFU, not between two p=
+articipants.
+
+> **Implementation Note =E2=80=94 SDP Sanitization and Trickle ICE**: The SD=
+P sanitization rules above apply to any `a=3Dcandidate` lines embedded in th=
+e SDP offer/answer itself. When using Trickle ICE (kind 453), many WebRTC im=
+plementations send an empty candidate section in the SDP and rely entirely o=
+n kind 453 events for candidate exchange. The ICE candidate filtering rules i=
+n Privacy Enhancements apply to BOTH SDP-embedded candidates and trickled ca=
+ndidates in kind 453 events. Implementations MUST apply the same filtering r=
+egardless of which transport the candidate arrives in.
+
+#### ICE Candidate (kind 453)
+
+```json
+{
+    "kind": 453,
+    "created_at": 1693876725,
+    "pubkey": "<sender_nostr_pubkey>",
+    "content": "<ice_candidate_json>",
+    "tags": [
+        ["call_id", "<call_id>"],
+        ["target_leaf", "<leaf_index>"]
+    ]
+}
+```
+
+Trickle ICE (RFC 8838): candidates sent as discovered. Empty `content` signa=
+ls end-of-candidates. ICE candidate filtering rules are specified in Privacy=
+ Enhancements and MUST be applied before sending.
+
+#### Call State Update (kind 454)
+
+```json
+{
+    "kind": 454,
+    "created_at": 1693876800,
+    "pubkey": "<sender_nostr_pubkey>",
+    "content": "",
+    "tags": [
+        ["call_id", "<call_id>"],
+        ["action", "<action_type>"],
+        ["reason", "<optional_reason>"],
+        ["sfu", "<sfu_pubkey_hex>", "<sfu_websocket_url>"],
+        ["recording", "start|stop"]
+    ]
+}
+```
+
+**Action types**: `"mute_audio"`, `"unmute_audio"`, `"mute_video"`, `"unmute=
+_video"`, `"leave"`, `"end"`, `"hold"`, `"resume"`, `"screen_share_start"`, `=
+"screen_share_stop"`, `"renegotiate"`, `"speaker_focus"`, `"verify"`, `"veri=
+fy_response"`, `"recording_start"`, `"recording_stop"`, `"participant_joined=
+"`, `"participant_left"`, `"quality_report"`.
+
+`"end"` terminates the call for all participants. Any participant may send i=
+t; clients SHOULD prompt for confirmation if the sender is not the initiator=
+ or a group admin (per `admin_pubkeys` in MIP-01 0xF2EE extension). `"leave"=
+` affects only the sender. Mute state is informational for UI.
+
+`"renegotiate"` triggers a topology change (e.g., mesh =E2=86=92 SFU escalat=
+ion). When `action` is `"renegotiate"`, the `sfu` tag MUST be present and sp=
+ecifies the new SFU endpoint(s). All participants process this event and tra=
+nsition to the new topology. See Tier Selection.
+
+`"recording_start"` and `"recording_stop"` inform participants that a record=
+ing bot (see Recording) is active. The `recording` tag carries the start/sto=
+p value.
+
+`"quality_report"` carries client-measured call quality metrics in `content`=
+ as a JSON object (see Call Quality Metrics).
+
+Unknown action types MUST be ignored by receivers to allow future extension w=
+ithout protocol version changes.
+
+### Call Quality Metrics
+
+When `action` is `"quality_report"`, the `content` field of kind 454 carries=
+ a JSON object:
+
+```json
+{
+    "rtt_ms": 45,
+    "packet_loss_pct": 0.5,
+    "jitter_ms": 12,
+    "bitrate_kbps": 2400,
+    "codec": "video/av1",
+    "resolution": "720p",
+    "fps": 30
+}
+```
+
+All fields are OPTIONAL. Clients SHOULD send quality reports every 10 second=
+s during a call. These reports are informational =E2=80=94 they allow peer U=
+Is to display connection quality indicators and help with post-call diagnost=
+ics. Quality reports MUST NOT be used for automated call termination (only t=
+he user should decide to end a degraded call).
+
+### Signaling Latency Analysis
+
+**Key property**: The call signaling path is structurally equivalent to cent=
+ralized services like Signal, whether the recipient is online or offline:
+
+| Path segment | Signal | Marmot | Delta |
+|-------------|--------|--------|-------|
+| Recipient online | Client =E2=86=92 server =E2=86=92 pushes to open connec=
+tion | Client =E2=86=92 Nostr relay =E2=86=92 pushes to open WebSocket subsc=
+ription | ~0 (single-hop both ways) |
+| Recipient offline | Server =E2=86=92 APNs/FCM =E2=86=92 device wakes =E2=86=
+=92 fetches signaling | Caller =E2=86=92 APNs/FCM via MIP-05 =E2=86=92 devic=
+e wakes =E2=86=92 fetches kind 450 from relay | ~0 (same push infrastructure=
+, same 1=E2=80=934s wake latency) |
+| Crypto overhead | Encrypt/decrypt signaling | MLS encrypt/decrypt (~1=E2=80=
+=932ms) | Negligible |
+| ICE/DTLS setup | Standard WebRTC | Standard WebRTC | Identical |
+
+When the caller initiates a call, two things happen simultaneously: the kind=
+ 450 event is published to the group's Nostr relays, and MIP-05 push notific=
+ations are sent to all members' devices. This covers both cases:
+
+- **Online devices** receive the kind 450 immediately via their existing Web=
+Socket subscription to the relay (the same persistent connection used for MI=
+P-03 messages). Delivery is typically single-digit milliseconds.
+- **Offline devices** are woken by APNs/FCM via MIP-05. The device connects t=
+o the relay, fetches the kind 450, MLS-decrypts it, discovers it is a call, a=
+nd presents the ringing UI. The additional fetch-and-decrypt step adds negli=
+gible time since the event is already stored on the relay. Total wake-to-rin=
+g latency is approximately 1=E2=80=934 seconds =E2=80=94 the same range as S=
+ignal and WhatsApp, using the same APNs/FCM infrastructure.
+
+Once the callee responds (kind 451 `"accept"`), the remaining signaling even=
+ts (SDP offer/answer, ICE candidates) travel the same relay path, and once I=
+CE/DTLS completes, media flows directly peer-to-peer (mesh) or through the S=
+FU =E2=80=94 identical to any WebRTC implementation.
+
+The protocol does NOT introduce an inherent latency disadvantage in either t=
+he online or offline case. What it introduces is variability in the online p=
+ath: because Marmot does not control relay infrastructure the way Signal con=
+trols its servers, signaling delivery speed depends on relay quality. A well=
+-provisioned relay in a nearby datacenter delivers events in single-digit mi=
+lliseconds, comparable to Signal's servers. A poorly provisioned relay in a d=
+istant region may not. This is an infrastructure provisioning concern, not a=
+ protocol limitation. Clients SHOULD prefer relays and SFUs with low measure=
+d round-trip times, and groups SHOULD configure relay and SFU preferences (v=
+ia MIP-01 0xF2EE extension) to avoid high-latency infrastructure.
+
+**Optimizations**:
+
+1. **Parallel push and relay signaling**: caller publishes kind 450 to relay=
+s and triggers MIP-05 push simultaneously, ensuring both online and offline d=
+evices are reached with no sequential delay
+2. **Pre-connection to shared relays**: online devices receive signaling eve=
+nts via existing WebSocket subscriptions with no connection setup overhead
+3. **Parallel ICE and signaling**: begin ICE gathering before SDP constructi=
+on; trickle candidates via kind 453
+4. **Aggressive ICE nomination**: select connectivity pairs as fast as possi=
+ble
+5. **Relay coalescing**: publish to the subset of group relays most likely t=
+o reach the callee
+
+## Media Topology
+
+### Tier 1: Mesh (2=E2=80=938 Audio / 2=E2=80=934 Video Participants)
+
+```text
+     Alice =E2=86=90=E2=86=92 Bob
+       =E2=86=95   =E2=9C=95   =E2=86=95
+     Carol =E2=86=90=E2=86=92 Dave
+```
+
+Each participant establishes a direct WebRTC PeerConnection with every other=
+ participant, creating N=C3=97(N-1)/2 connections. Each participant sends N-=
+1 copies of their media. No SFU required.
+
+#### Mesh Signaling Flow
+
+1. Caller sends kind 450 with no `sfu` tag (indicating mesh topology)
+2. Callees respond with kind 451 `"accept"`
+3. For each pair of participants, the participant with the lower MLS leaf in=
+dex sends the SDP offer (kind 452), the other sends the answer. This determi=
+nistic rule prevents offer collisions
+4. ICE candidates are trickled via kind 453, with `target_leaf` identifying t=
+he specific peer
+5. Each PeerConnection completes ICE/DTLS independently
+
+#### Mesh Encryption
+
+SFrame encryption is applied in mesh mode identically to SFU mode =E2=80=94 e=
+very audio, video, and screen share frame is SFrame-encrypted before transmi=
+ssion, using the same key derivation, KID structure, and cipher suite. The e=
+ncryption pipeline is:
+
+```text
+Capture =E2=86=92 Encode =E2=86=92 [SFrame Encrypt] =E2=86=92 Packetize =E2=86=
+=92 DTLS-SRTP =E2=86=92 Peer
+Peer =E2=86=92 DTLS-SRTP =E2=86=92 Depacketize =E2=86=92 [SFrame Decrypt] =E2=
+=86=92 Decode =E2=86=92 Render
+```
+
+This means mesh calls have two layers of encryption: SFrame (end-to-end, key=
+ed from MLS) inside DTLS-SRTP (hop-by-hop, keyed from the DTLS handshake). T=
+his is intentional for three reasons:
+
+1. **Uniform encryption model**: The same SFrame code path runs regardless o=
+f topology. When a call escalates from mesh to SFU (via kind 454 `"renegotia=
+te"`), there is no encryption renegotiation =E2=80=94 senders continue encry=
+pting frames with the same SFrame keys, and only the transport layer changes=
+ (direct PeerConnection =E2=86=92 SFU-routed PeerConnection). This eliminate=
+s a class of transition bugs and key synchronization races
+2. **TURN server protection**: In standard privacy mode, some mesh connectio=
+ns may be relayed through TURN servers for NAT traversal. Standard DTLS-SRTP=
+ terminates at each hop, meaning a compromised TURN relay could access plain=
+text media. SFrame inside DTLS-SRTP ensures media remains opaque even if the=
+ TURN relay is compromised. In enhanced privacy mode (where ALL connections u=
+se TURN), this property is essential
+3. **Consistent receiver logic**: The receiver always parses the SFrame head=
+er to identify the sender (via KID =E2=86=92 leaf_index) and select the corr=
+ect decryption key. This works identically whether the frame arrived via a d=
+irect PeerConnection or an SFU. Receivers do not need to know the topology
+
+> **Design Rationale =E2=80=94 Why Not Skip SFrame in Mesh?** For a 1:1 call=
+ with no TURN relay, DTLS-SRTP alone provides equivalent content protection.=
+ An implementation could theoretically skip SFrame in this case. However, th=
+e complexity of maintaining two encryption code paths (SFrame-on for SFU, SFra=
+me-off for mesh) and handling the transition between them outweighs the ~18 b=
+ytes per frame saved. The spec therefore requires SFrame in all topologies f=
+or simplicity and uniformity.
+
+#### Mesh Bandwidth
+
+The practical mesh limit depends on media type because upload bandwidth scal=
+es as (N-1) =C3=97 bitrate per stream:
+
+| Participants | Audio upload (Opus 50 kbps) | Video upload (720p ~2 Mbps) |=
+
+|-------------|---------------------------|----------------------------|
+| 2 | 50 kbps | 2 Mbps |
+| 4 | 150 kbps | 6 Mbps |
+| 5 | 200 kbps | 8 Mbps |
+| 8 | 350 kbps | 14 Mbps |
+
+Audio-only calls can comfortably mesh up to 8 participants =E2=80=94 350 kbp=
+s upload is trivial on any modern connection. Video calls hit practical limi=
+ts at 4=E2=80=935 participants, where 6=E2=80=938 Mbps upload saturates typi=
+cal mobile uplinks and causes packet loss, freezing, and audio dropouts. Cli=
+ents SHOULD use `call_type` from the kind 450 event to select the mesh thres=
+hold: up to 8 participants for `"audio"`, up to 4 for `"video"`.
+
+### Tier 2: Single SFU (5=E2=80=93100 Video / 9=E2=80=93100 Audio Participan=
+ts)
+
+```text
+  Alice =E2=86=92 SFU =E2=86=92 Bob
+  Carol =E2=86=97     =E2=86=98 Dave
+```
+
+Each participant sends one stream to the SFU (or 2=E2=80=933 with SVC layers=
+, ~3 Mbps). SFU forwards encrypted streams to subscribers. Each participant a=
+uthenticates with the SFU (see SFU Authentication) and creates a single Peer=
+Connection.
+
+### Tier 3: Cascaded SFU Federation (100+ Participants)
+
+```text
+             Root SFU
+            /    |    \
+       SFU-A   SFU-B   SFU-C
+      /  |  \   |  \     |  \
+   users  users  users  users
+```
+
+Each participant connects to nearest SFU. SFUs relay only the active speaker=
+s' streams inter-SFU (not all streams), so inter-SFU bandwidth scales with t=
+he number of concurrent speakers rather than total participants. In practice=
+, conversation dynamics limit simultaneous speakers =E2=80=94 even in large m=
+eetings, only one or two people speak at a time, with occasional brief overl=
+aps.
+
+> **Note =E2=80=94 Cascaded Federation Scope**: The inter-SFU communication p=
+rotocol (how SFUs discover each other, authenticate, and relay media) is int=
+entionally deferred to a future specification. This MIP defines only the cli=
+ent-facing behavior: when multiple `sfu` tags are present in kind 450, the c=
+lient connects to the nearest SFU endpoint. The SFU operators are responsibl=
+e for establishing the federation mesh between their instances. A future MIP=
+ MAY define a standardized inter-SFU protocol to ensure interoperability bet=
+ween SFU implementations from different operators.
+
+### Tier Selection
+
+Clients MUST support Tier 1. Clients SHOULD support Tier 2. Clients MAY supp=
+ort Tier 3. Topology is determined by the kind 450's `sfu` tags: zero =E2=86=
+=92 mesh, one =E2=86=92 single SFU, multiple =E2=86=92 cascaded.
+
+When no `sfu` tag is present (mesh mode), clients SHOULD enforce the mesh pa=
+rticipant limit based on `call_type`: 4 participants for `"video"`, 8 for `"=
+audio"`. If additional participants attempt to join beyond the mesh limit, a=
+ny participant MAY escalate to SFU mode by sending a kind 454 event with act=
+ion `"renegotiate"` and an `sfu` tag specifying the new SFU endpoint. All pa=
+rticipants MUST process this event and transition to the SFU topology. Durin=
+g transition, clients SHOULD maintain the existing mesh connections until th=
+e SFU connection is established, then tear down mesh PeerConnections.
+
+Clients that cannot support the selected tier SHOULD send kind 451 with `"de=
+cline"` and reason `"unsupported_topology"`.
+
+## Active Speaker Detection and Bandwidth Adaptation
+
+### Specification
+
+SFUs read the `ssrc-audio-level` RTP header extension (RFC 6464) =E2=80=94 a=
+ 7-bit audio level in -dBov (0 =3D loudest, 127 =3D silence) plus 1-bit VAD f=
+lag =E2=80=94 from each sender's packets. The SFU applies smoothing with hys=
+teresis to rank speakers and forward high-quality video only for the top N (=
+Last-N). Recommended tuning: exponential moving average over 200=E2=80=93500=
+ms with 1=E2=80=932 second hold time before demoting a speaker, to avoid rap=
+id switching during brief pauses. These are implementation-level tuning para=
+meters, not protocol requirements.
+
+**Bandwidth reference**:
+
+| Mode | Bitrate per stream |
+|------|--------------------|
+| Audio only (Opus, mono, 20ms) | 32=E2=80=9350 kbps |
+| Low video (180p) | 100=E2=80=93150 kbps |
+| SD video (360p) | 400=E2=80=93500 kbps |
+| HD video (720p) | 1.5=E2=80=932.5 Mbps |
+| SVC source (720p, 3T+2S layers) | ~3 Mbps total |
+
+When the active speaker changes, the SFU sends a PLI (Picture Loss Indicatio=
+n) requesting a keyframe from the new speaker. The transition delay depends o=
+n the sender's keyframe generation speed, which varies by codec and resoluti=
+on =E2=80=94 typically one RTT for the PLI to reach the sender plus one fram=
+e interval for the keyframe to be generated and arrive. Per-subscriber bandw=
+idth estimation uses Transport-CC (draft-ietf-avt-cc-feedback): each RTP pac=
+ket carries a transport-wide sequence number, receivers report per-packet ar=
+rival times, and senders run GCC (Google Congestion Control) to estimate ava=
+ilable bandwidth.
+
+### Design Rationale
+
+`ssrc-audio-level` is NOT encrypted by SFrame =E2=80=94 it is an RTP header e=
+xtension outside the media payload. This is an intentional metadata tradeoff=
+: it enables SFU routing intelligence without decrypting content. Enhanced p=
+rivacy mode mitigates this (see Privacy Enhancements). Last-N significantly r=
+educes server egress: in a 10-participant call, forwarding only the top 3 ac=
+tive speakers' video instead of all 10 reduces video forwarding by 70% per s=
+ubscriber (7 of 10 streams dropped), with proportional savings in packet pro=
+cessing.
+
+## SFU Discovery and Advertisement
+
+### SFU Advertisement (kind 10052)
+
+```json
+{
+    "kind": 10052,
+    "created_at": 1693876700,
+    "pubkey": "<sfu_operator_nostr_pubkey>",
+    "content": "",
+    "tags": [
+        ["url", "wss://sfu1.example.com/marmot"],
+        ["url", "wss://sfu2.example.com/marmot"],
+        ["region", "us-east"],
+        ["region", "eu-west"],
+        ["capacity", "200"],
+        ["protocols", "webrtc", "whip", "whep"],
+        ["relay", "wss://relay.example.com"],
+        ["turn", "turn:turn.example.com:3478", "hmac-sha1"]
+    ]
+}
+```
+
+**Tags**: `url` (WebSocket signaling endpoints), `region` (geographic, infor=
+mational), `capacity` (max participants, informational), `protocols` (`"webr=
+tc"` required; `"whip"` RFC 9725 and `"whep"` optional), `relay` (Nostr rela=
+ys for discovery), `turn` (co-located TURN URI and credential mechanism).
+
+**Discovery**: clients query known relays for kind 10052 from trusted SFU op=
+erator pubkeys, select by proximity/capacity/trust, include in kind 450's `s=
+fu` tag. Groups MAY store preferred SFU operator pubkeys in the 0xF2EE exten=
+sion (MIP-01).
+
+### SFU Authentication
+
+#### Specification
+
+```text
+sfu_auth_token =3D MLS-Exporter(
+    label:   "marmot-sfu-auth-v1",
+    context: call_id || sfu_pubkey,
+    length:  32
+)
+```
+
+> **Implementation Note**: The same HKDF-Expand-only caveat applies here. `s=
+fu_auth_token` is derived from the MLS exporter secret, which is already a P=
+RK. Use HKDF-Expand directly.
+
+**Flow**:
+1. Client connects to SFU WebSocket
+2. Client sends: `{"type": "auth", "call_id": "<hex>", "leaf_index": <number=
+>, "token": "<hex>"}`
+3. SFU responds: `{"type": "auth_ok", "participant_count": <number>}` on suc=
+cess, or `{"type": "auth_error", "reason": "invalid_token|room_full|rate_lim=
+ited"}` on failure
+4. SFU: if new call_id, store token as room key. If existing call_id, verify=
+ token matches
+5. SFU admits or rejects. On rejection, SFU SHOULD close the WebSocket with c=
+ode 4001 (unauthorized) or 4002 (room full)
+
+The token rotates on MLS epoch change. Clients MUST re-authenticate with the=
+ new token after epoch transitions. To re-authenticate, the client sends a n=
+ew `auth` message with the updated token on the existing WebSocket; the SFU r=
+eplaces the stored room key. During re-authentication, the SFU MUST continue=
+ forwarding media (do not interrupt the call).
+
+**SFU Participant Tracking**: The SFU MUST track connected participants by `=
+leaf_index` and SHOULD broadcast participant count changes to all connected c=
+lients via: `{"type": "participant_update", "participants": [<leaf_index>, .=
+..], "count": <number>}`. This enables clients to detect unexpected particip=
+ants (see Security Considerations).
+
+#### Design Rationale
+
+The SFU never learns Nostr identities =E2=80=94 it sees only a bearer token p=
+roving MLS group membership. Binding the token to both `call_id` and `sfu_pu=
+bkey` prevents reuse across different calls or SFUs. All legitimate particip=
+ants derive the same token from shared MLS state.
+
+### Network Partition Recovery
+
+When a participant loses network connectivity and reconnects:
+
+1. If the WebSocket to the SFU is still open (e.g., brief network blip < TCP=
+ timeout), media resumes automatically via ICE restart
+2. If the WebSocket was closed, the client MUST re-establish the WebSocket c=
+onnection, re-authenticate with the current epoch's `sfu_auth_token`, and se=
+nd a new SDP offer
+3. If the MLS epoch changed during disconnection, the client MUST first proc=
+ess all pending MLS commits (fetched from Nostr relays), derive the current e=
+poch's keys, then re-authenticate with the SFU
+4. Clients SHOULD attempt reconnection with exponential backoff (1s, 2s, 4s,=
+ 8s, max 30s) for up to 60 seconds before displaying "call ended" to the use=
+r
+5. During reconnection, clients SHOULD display a "reconnecting..." indicator=
+ in the call UI
+
+## Triggering Call Notifications via MIP-05
+
+### Specification
+
+1. Caller publishes kind 450 as MLS Application Message (kind 445) to group r=
+elays
+2. Caller constructs gift-wrapped notification (kind 446 rumor =E2=86=92 kin=
+d 13 seal =E2=86=92 kind 1059 gift wrap) per MIP-05 using stored encrypted p=
+ush tokens
+3. Caller publishes gift wrap to notification server's inbox relays (from se=
+rver's kind 10050)
+4. Server unwraps, decrypts tokens, fires silent push to APNs/FCM
+5. Woken devices fetch events from relays, discover kind 450, present ringin=
+g UI
+6. User accepts (kind 451 `"accept"`) or declines (kind 451 `"decline"`)
+
+If the kind 450 is older than 60 seconds when the device wakes, clients SHOU=
+LD treat it as a missed call. Ring timeout: 30 seconds without response =E2=86=
+=92 caller UI shows "no answer."
+
+### Design Rationale
+
+The push notification is silent and content-free per MIP-05. The woken clien=
+t discovers it is a call (not a message) only after fetching and decrypting t=
+he kind 450. This means Apple/Google cannot distinguish call notifications f=
+rom message notifications, preserving the MIP-05 privacy property.
+
+## Multi-Device Call Handling
+
+### Specification
+
+1. All devices (MLS leaves) decrypt the kind 450 and present ringing UI
+2. MIP-05 push wakes offline devices
+3. First device to send kind 451 `"accept"` joins the call
+4. Other devices belonging to the same user (identified by shared Nostr pubk=
+ey across MLS credentials per MIP-00) observe the accept and cancel ringing
+5. Only the accepting device establishes a WebRTC session
+
+**Device switch**: new device sends kind 451 `"accept"`; both devices are te=
+mporarily active (separate MLS leaves, independent SFrame contexts). User se=
+nds kind 454 `"leave"` from original device.
+
+**Multiple active devices**: explicitly supported (e.g., phone for audio, ta=
+blet for screen share). Each device is a separate MLS leaf with independent k=
+ey material.
+
+## Codec Requirements
+
+### Specification
+
+**Audio**: Opus (RFC 6716) decoding MUST be supported. Opus SHOULD be config=
+ured at 48kHz mono with 20ms frames. In `"enhanced"` privacy mode: CBR at 32=
+ kbps, DTX disabled, silence suppression disabled.
+
+**Video**: VP8 (RFC 6386) decoding MUST be supported. AV1 with SVC SHOULD be=
+ preferred when both peers support it. VP9 SVC MAY be supported.
+
+**Screen share**: VP8 minimum. Screen content mode SHOULD be enabled.
+
+**Codec negotiation failure**: When participants support different video cod=
+ecs (e.g., one supports only VP8 and another prefers AV1), the call MUST fal=
+l back to the mandatory baseline codec (VP8 for video, Opus for audio). The S=
+FU MUST NOT transcode media, as transcoding would require decrypting SFrame p=
+ayloads and break E2EE. If no common codec can be negotiated, the participan=
+t with the lesser codec support SHOULD send kind 451 with `"decline"` and re=
+ason `"codec_mismatch"`, and the client MAY display a user-facing message su=
+ggesting the peer update their application.
+
+## Privacy Enhancements
+
+### Standard Mode (Default)
+
+- ICE: filter out RFC 1918 private host candidates. mDNS, server-reflexive, a=
+nd relay candidates permitted
+- Audio: variable bitrate
+- Video: adaptive bitrate
+- `ssrc-audio-level`: present (enables SFU speaker detection)
+
+### Enhanced Mode
+
+Specified via `privacy` tag `"enhanced"` in kind 450:
+
+- ICE: `iceTransportPolicy: "relay"` =E2=80=94 ONLY relay (TURN) candidates.=
+ Hides participant IPs from peers and SFU
+- Audio: CBR (constant bitrate) at 32 kbps. DTX and silence suppression disa=
+bled
+- Video: frames SHOULD be padded to nearest 256-byte boundary before SFrame e=
+ncryption
+- `ssrc-audio-level`: MAY be set to constant value (always 0). Disables SFU s=
+peaker detection =E2=80=94 clients use kind 454 `"speaker_focus"` instead
+- RTCP timestamps: SHOULD be randomized by a uniformly random offset within =C2=
+=B1500ms (chosen to exceed typical jitter buffer depth of 200=E2=80=93300ms,=
+ making timestamp-based correlation across streams unreliable while remainin=
+g small enough to not break RTCP timing for bandwidth estimation)
+
+### IP Address Privacy Summary
+
+| Candidate Type | Standard | Enhanced | Observer |
+|---------------|----------|----------|----------|
+| Host (RFC 1918) | Filtered | Filtered | =E2=80=94 |
+| Host (mDNS) | Allowed | Filtered | Local network only |
+| Server-reflexive | Allowed | Filtered | Peer + STUN server |
+| Relay (TURN) | Allowed | Required | TURN server only |
+
+### Design Rationale
+
+Enhanced mode trades bandwidth, quality, and latency for resistance to traff=
+ic analysis. The bandwidth cost of CBR depends on the VBR baseline: Opus VBR=
+ typically averages 20=E2=80=9330 kbps for speech (silence suppression and D=
+TX reduce it below the nominal rate), while CBR at 32 kbps transmits at a fi=
+xed rate regardless of speech activity. VBR codecs like Opus produce variabl=
+e-size packets that leak voice activity patterns, enabling ~48% speaker iden=
+tification accuracy with 20 speakers (Backes et al., 2010) and ~66% language=
+ identification across 21 languages (Wright et al.). CBR eliminates this sig=
+nal. Forced TURN prevents IP correlation between participants. This mode is i=
+ntended for high-risk users and SHOULD NOT be the default.
+
+## Verification
+
+### Specification
+
+**Epoch authenticator check**: Any participant sends kind 454 with action `"=
+verify"` and a random 16-byte `challenge` in the `reason` tag. Each particip=
+ant computes `response =3D HMAC-SHA256(epoch_authenticator, challenge)` (whe=
+re `epoch_authenticator` is from RFC 9420 =C2=A78.6) and replies with action=
+ `"verify_response"`. Matching responses confirm shared MLS state.
+
+**Safety numbers**: Clients MAY display a truncated visual representation of=
+ the `epoch_authenticator` (e.g., 6-digit numeric code or emoji sequence) fo=
+r verbal out-of-band comparison during the call.
+
+## Recording
+
+### Specification
+
+Server-side recording is impossible with SFrame E2EE. Recording uses a "reco=
+rding bot" as a full MLS group member:
+
+1. Bot is Added to group via MLS Add + Commit (visible to all members)
+2. Bot joins the call by sending kind 451 with `"accept"` and kind 454 with a=
+ction `"recording_start"`
+3. Bot holds SFrame keys and records decrypted media
+4. Bot SHOULD record to a standard container format (e.g., WebM with Opus au=
+dio and VP8/AV1 video)
+5. When recording ends, bot sends kind 454 with action `"recording_stop"`, t=
+hen kind 454 with `"leave"`
+6. When the bot is no longer needed, it is Removed via MLS Remove + Commit (=
+epoch rotates, bot loses future keys)
+
+**Transparency**: MLS guarantees all group operations are visible to all mem=
+bers. A recording bot CANNOT exist without appearing in the member list =E2=80=
+=94 this is a structural property of MLS, not a policy decision. The `"recor=
+ding_start"` and `"recording_stop"` kind 454 actions provide additional in-c=
+all visibility. Clients SHOULD display a prominent recording indicator in th=
+e call UI when a `"recording_start"` event has been received without a corre=
+sponding `"recording_stop"`.
+
+**Moderation**: Group admins (per `admin_pubkeys` in 0xF2EE) can terminate c=
+alls via kind 454 `"end"`. SFU-level muting (packet dropping) provides immed=
+iate enforcement. MLS Remove provides cryptographic enforcement.
+
+## Security Considerations
+
+This section covers residual risks, attack trees, and trust assumptions. The=
+ Privacy Properties table in the Architecture section is the authoritative r=
+eference for information flow.
+
+### Trust Assumptions
+
+1. **MLS group members**: All members can derive SFrame keys. The call's enc=
+ryption boundary is the MLS group (see Design Rationale under Architecture)
+2. **SFU operator** (if used): routes packets honestly. Compromise does not b=
+reak content confidentiality (SFrame E2EE), but enables metadata surveillanc=
+e per Privacy Properties table
+3. **TURN operator** (if used): relays packets. Sees IP addresses per Privac=
+y Properties table, not content
+4. **Apple/Google** (for push): per MIP-05 properties
+
+### Attack Trees
+
+**Compromised SFU**: Cannot decrypt media (no MLS keys). Can: selectively dr=
+op packets (detectable by client quality metrics and kind 454 `"quality_repo=
+rt"` events), replay frames (rejected =E2=80=94 SFrame CTR must be monotonic=
+; replayed CTR values are discarded), observe metadata per Privacy Propertie=
+s, refuse service. Cannot: inject fabricated media (GCM tag verification fai=
+ls), access past/future media, determine Nostr identities. Detection: client=
+s can cross-reference expected participant count (from kind 451 signaling) w=
+ith the SFU's `participant_update` messages to detect phantom participants.
+
+**Compromised TURN**: Cannot decrypt content (SFrame inside SRTP). In enhanc=
+ed mode, concentrates IP exposure at TURN operator but hides participants fr=
+om each other and from SFU.
+
+**Compromised relay**: Cannot read signaling (MLS-encrypted). Can delay/drop=
+ events (mitigated by multiple relays).
+
+**Malicious group member not on call**: Possesses SFrame base key. Would nee=
+d to independently connect to SFU with derived auth token and silently recei=
+ve media =E2=80=94 equivalent to joining the call. Detectable: the SFU's `pa=
+rticipant_update` message will include the attacker's leaf_index, which othe=
+r participants can compare against the set of participants who sent kind 451=
+ `"accept"`. If a leaf_index appears in the SFU's participant list but did n=
+ot send an `"accept"` event, clients SHOULD alert the user. Mitigated by cre=
+ating a dedicated MLS subgroup if needed.
+
+**Traffic analysis**: VBR audio leaks speech patterns. Video bitrate reveals=
+ resolution/motion. Keyframes (5=E2=80=9310=C3=97 larger than P-frames) are d=
+etectable. Enhanced privacy mode (CBR, padding, forced TURN) mitigates at ba=
+ndwidth cost. Note: even with CBR audio, packet timing patterns may still le=
+ak information about call structure (number of active speakers, conversation=
+ turn-taking patterns). A formal traffic analysis of enhanced mode against s=
+tate-of-the-art classifiers is recommended before deploying in high-risk env=
+ironments.
+
+**Forced rapid epoch transitions**: If an attacker can trigger rapid MLS epo=
+ch changes (e.g., by repeatedly joining and leaving the group), the CTR rese=
+t-to-zero on each epoch change creates predictable nonce patterns across dif=
+ferent epoch keys. While this is not a nonce-reuse vulnerability (keys chang=
+e with each epoch), the predictability could be relevant for multi-key attac=
+ks on AES-GCM in adversarial settings. Mitigation: group admins SHOULD rate-=
+limit join/leave operations during active calls (e.g., reject commits that w=
+ould cause more than 4 epoch transitions per minute during an active call). T=
+his is a client-level policy, not a protocol-level enforcement.
+
+### Epoch Transition Security
+
+When a member is removed during a call:
+1. Remove + Commit processed by remaining members
+2. Removed member cannot compute new epoch's `exporter_secret` (path_secret w=
+as encrypted only to remaining subtrees)
+3. New `call_base_key` derived; senders switch to new-epoch keys
+4. Removed member's SFU auth token is invalid (derived from old epoch)
+5. After 2-second grace period, old keys discarded (securely zeroed)
+
+## Versioning and Extensibility
+
+### Current Version
+
+This specification is version 1, identified by the exporter labels `"marmot-=
+call-v1"` and `"marmot-sfu-auth-v1"`.
+
+### Future Versions
+
+A future version 2 would use labels `"marmot-call-v2"` and `"marmot-sfu-auth=
+-v2"`. Because the exporter label is embedded in the key derivation, version=
+ 1 and version 2 keys are cryptographically independent =E2=80=94 there is n=
+o risk of cross-version key collision.
+
+Version negotiation is implicit: the kind 450 event's tag set defines which f=
+eatures the call uses. A future version MAY add a `["version", "2"]` tag to k=
+ind 450. Clients that do not recognize this tag SHOULD decline the call with=
+ reason `"unsupported_version"`.
+
+Backward compatibility is not guaranteed across major versions. Clients MUST=
+ NOT attempt to join a call whose version they do not support.
+
+### Extension Points
+
+New media types beyond audio (0x00), video (0x01), and screen share (0x02) c=
+an be added by assigning new `media_type` values without changing the KID st=
+ructure. New kind 454 action types can be added without protocol version cha=
+nges (unknown actions MUST be ignored by receivers). New tags on kind 450 ca=
+n add capabilities without breaking existing clients (unknown tags MUST be i=
+gnored).
+
+## Known Underspecified Areas
+
+The following areas are intentionally deferred or identified as needing furt=
+her specification. They are listed here to guide reviewers and future work.
+
+1. **Cascaded SFU federation protocol**: How SFUs discover, authenticate, an=
+d relay media between each other is not defined. This MIP specifies only the=
+ client-facing behavior for Tier 3 topology. A future MIP SHOULD define a st=
+andardized inter-SFU protocol.
+
+2. **Call merging**: If two subsets of a group independently initiate calls (=
+different `call_id` values), there is no mechanism to merge them. A future e=
+xtension MAY define a `"merge"` action type for kind 454 with a `target_call=
+_id` tag.
+
+3. **SRTP key fingerprint verification**: In mesh mode, participants establi=
+sh direct DTLS-SRTP connections. The DTLS certificate fingerprints are not c=
+urrently bound to MLS identities. A future version MAY require embedding the=
+ DTLS fingerprint in kind 452 events and verifying it matches the peer's DTL=
+S handshake.
+
+4. **Formal traffic analysis of enhanced mode**: The privacy enhancements (C=
+BR, padding, forced TURN) are described but not formally analyzed against st=
+ate-of-the-art traffic classifiers. High-risk deployments should commission i=
+ndependent analysis.
+
+5. **SFU billing and resource limits**: The spec does not define how SFU ope=
+rators signal resource exhaustion, billing, or usage limits. The `capacity` t=
+ag in kind 10052 is informational only.
+
+6. **Call history and missed call UI**: The spec defines timeouts (30s ring,=
+ 60s missed) but does not specify how clients should persist or display call=
+ history. This is left to client implementation.
+
+## Implementation Requirements
+
+### Client Requirements
+
+Clients MUST:
+- Support WebRTC with SFrame via `RTCRtpScriptTransform` (or legacy `createE=
+ncodedStreams` for Chrome)
+- Derive `call_base_key` via MLS-Exporter with label `"marmot-call-v1"` and c=
+all_id as context
+- Derive per-sender `sframe_base_key` via HKDF-Expand (NOT Extract-then-Expa=
+nd) per Key Derivation specification
+- Implement SFrame with cipher suite `AES_128_GCM_SHA256_128` (0x0001)
+- Implement KID structure per KID Structure specification
+- Derive SFU auth tokens with label `"marmot-sfu-auth-v1"` when connecting t=
+o SFUs
+- Support Tier 1 mesh (2=E2=80=934 participants)
+- Implement kinds 450=E2=80=93454 as unsigned MLS Application Messages per M=
+IP-03
+- Verify sender's MLS identity when processing signaling events
+- Filter RFC 1918 private IP host candidates from ICE in all privacy modes (=
+both SDP-embedded and trickled candidates)
+- Reject duplicate call_ids
+- Retain previous epoch's SFrame keys for 2 seconds; reset CTR to 0 on epoch=
+ change
+- Securely zero key material when discarding epoch keys
+- Support Opus decoding and VP8 decoding
+- Cancel ringing when another device owned by the same user accepts
+- Ignore unknown kind 454 action types
+- Ignore unknown tags on kind 450
+
+Clients SHOULD:
+- Support Tier 2 (single SFU)
+- Trigger MIP-05 push on call initiation
+- Implement Trickle ICE and aggressive nomination
+- Prefer AV1 SVC or VP9 SVC for SFU-routed calls
+- Use Dependency Descriptor RTP header extension for SVC
+- Sanitize SDP (remove hostname from `o=3D` line)
+- Display ringing UI for kind 450 events less than 60 seconds old; stop afte=
+r 30 seconds
+- Implement safety number display for verification
+- Send kind 454 `"quality_report"` every 10 seconds during calls
+- Display recording indicator when `"recording_start"` is active
+- Implement reconnection with exponential backoff on network partition
+
+Clients MAY:
+- Support Tier 3 (cascaded SFU)
+- Support screen sharing (media_type 0x02)
+- Support WHIP/WHEP for broadcast
+- Support `"enhanced"` privacy mode
+- Support recording bot pattern
+
+### SFU Requirements
+
+SFUs MUST:
+- Forward SFrame payloads without modification (no decryption, no transcodin=
+g)
+- Support DTLS-SRTP and BUNDLE
+- Implement bearer-token authentication per SFU Authentication specification=
+
+- Support Transport-CC for bandwidth estimation
+- Respond to `auth` messages with `auth_ok` or `auth_error` per the defined p=
+rotocol
+- Track connected participants by leaf_index
+- Close WebSocket connections with appropriate error codes on authentication=
+ failure
+
+SFUs SHOULD:
+- Support Dependency Descriptor for SVC layer selection
+- Implement `ssrc-audio-level` active speaker detection
+- Implement Last-N video forwarding
+- Publish kind 10052 advertisement
+- Support NACK retransmission and PLI/FIR keyframe requests
+- Broadcast `participant_update` messages on join/leave
+- Support token rotation during epoch transitions without interrupting media=
+
+
+## Wire Format and Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| MLS Exporter label (call) | `"marmot-call-v1"` | Call base key derivation |=
+
+| MLS Exporter label (SFU) | `"marmot-sfu-auth-v1"` | SFU authentication tok=
+en |
+| SFrame cipher suite | `AES_128_GCM_SHA256_128` (0x0001) | Encryption algor=
+ithm |
+| SFrame Nk | 16 bytes | AES-128 key size |
+| SFrame Nn | 12 bytes | GCM nonce size |
+| SFrame Nt | 16 bytes | GCM authentication tag size |
+| SFrame Nh | 32 bytes | SHA-256 hash size |
+| KID epoch bits (E) | 4 | Supports 16 simultaneous epochs |
+| KID sender bits (S) default | 6 | Supports up to 64 members |
+| media_type: audio | 0x00 | =E2=80=94 |
+| media_type: video | 0x01 | =E2=80=94 |
+| media_type: screen share | 0x02 | =E2=80=94 |
+| call_id size | 32 bytes | CSPRNG random |
+| sfu_auth_token size | 32 bytes | MLS-derived bearer token |
+| Epoch key grace period | 2 seconds | Old key retention |
+| Ring timeout | 30 seconds | Before "no answer" |
+| Missed call threshold | 60 seconds | Before treating as missed |
+| Video padding alignment | 256 bytes | Enhanced mode only |
+| Quality report interval | 10 seconds | Client =E2=86=92 group |
+| Reconnection max backoff | 30 seconds | Exponential backoff ceiling |
+| Reconnection max duration | 60 seconds | Before "call ended" |
+
+| Kind | Name | Signed | Scope |
+|------|------|--------|-------|
+| 450 | Call Initiation | Unsigned | MLS App Msg in kind 445 |
+| 451 | Call Answer | Unsigned | MLS App Msg in kind 445 |
+| 452 | WebRTC Session Description | Unsigned | MLS App Msg in kind 445 |
+| 453 | ICE Candidate | Unsigned | MLS App Msg in kind 445 |
+| 454 | Call State Update | Unsigned | MLS App Msg in kind 445 |
+| 10052 | SFU Advertisement | Signed | Replaceable event, public relays |
+
+### SFU WebSocket Protocol
+
+| Direction | Message | Fields |
+|-----------|---------|--------|
+| Client =E2=86=92 SFU | `auth` | `type`, `call_id`, `leaf_index`, `token` |=
+
+| SFU =E2=86=92 Client | `auth_ok` | `type`, `participant_count` |
+| SFU =E2=86=92 Client | `auth_error` | `type`, `reason` |
+| SFU =E2=86=92 Client | `participant_update` | `type`, `participants` (arra=
+y of leaf_index), `count` |
+
+WebSocket close codes: `4001` (unauthorized), `4002` (room full), `4003` (ra=
+te limited).
+
+### Key Derivation Chain
+
+```text
+MLS Ratchet Tree =E2=86=92 commit_secret =E2=86=92 epoch_secret =E2=86=92 ex=
+porter_secret
+
+call_base_key =3D MLS-Exporter("marmot-call-v1", call_id, 32)
+
+                 =E2=94=8C=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=
+=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=
+=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=
+=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=
+=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=
+=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=90
+                 =E2=94=82 HKDF-Expand ONLY (call_base_key is already  =E2=94=
+=82
+                 =E2=94=82 a PRK =E2=80=94 do NOT run HKDF-Extract first)   =
+   =E2=94=82
+                 =E2=94=94=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=
+=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=
+=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=
+=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=
+=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=
+=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=98
+
+sframe_base_key =3D HKDF-Expand(call_base_key,
+    "sframe" || media_type || leaf_index_BE32, 16)
+
+                 =E2=94=8C=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=
+=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=
+=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=
+=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=
+=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=
+=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=90
+                 =E2=94=82 HKDF-Extract then Expand (sframe_base_key   =E2=94=
+=82
+                 =E2=94=82 is NOT yet a PRK =E2=80=94 Extract is needed here=
+)  =E2=94=82
+                 =E2=94=94=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=
+=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=
+=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=
+=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=
+=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=
+=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=80=E2=94=98
+
+sframe_secret =3D HKDF-Extract("", sframe_base_key)
+
+sframe_key  =3D HKDF-Expand(sframe_secret,
+    "SFrame 1.0 Secret key" || KID_8BE || 0x0001, 16)
+
+sframe_salt =3D HKDF-Expand(sframe_secret,
+    "SFrame 1.0 Secret salt" || KID_8BE || 0x0001, 12)
+
+nonce =3D XOR(sframe_salt, big_endian(CTR, 12))
+
+ciphertext =3D AES-128-GCM(sframe_key, nonce, sframe_header, plaintext)
+
+sfu_auth_token =3D MLS-Exporter("marmot-sfu-auth-v1", call_id || sfu_pubkey,=
+ 32)
+```
+
+## Test Vectors
+
+All values are hex-encoded. HKDF uses SHA-256 throughout.
+
+### Inputs
+
+```
+call_id (32 bytes):
+  0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20
+
+call_base_key (32 bytes, assumed output of MLS-Exporter):
+  a1b2c3d4e5f60718293040506070809011223344556677881a2b3c4d5e6f7080
+
+Sender: leaf_index =3D 3
+KID parameters: E =3D 4, S =3D 6
+```
+
+### Per-Sender SFrame Base Key (audio, leaf 3)
+
+```
+HKDF-Expand PRK:  a1b2c3d4e5f60718293040506070809011223344556677881a2b3c4d5e=
+6f7080
+HKDF-Expand info: 736672616d650000000003
+                   ("sframe" || 0x00 || 0x00000003)
+HKDF-Expand L:    16
+
+sframe_base_key:  f7e6b52974ca5061636fe0357f6f005e
+```
+
+### Per-Sender SFrame Base Key (video, leaf 3)
+
+```
+HKDF-Expand info: 736672616d650100000003
+                   ("sframe" || 0x01 || 0x00000003)
+
+sframe_base_key:  af1c783f6b62d28b365d4865c41572ec
+```
+
+### SFrame Key Schedule (audio, leaf 3, epoch 0)
+
+```
+KID =3D (0 << 10) | (3 << 4) | 0 =3D 48 (0x0030)
+KID_8BE: 0000000000000030
+CS:      0001
+
+sframe_secret =3D HKDF-Extract("", f7e6b52974ca5061636fe0357f6f005e):
+  d46e1ee2c201996bb9ca64bd03962d2ddfd6f303e9e5cf621a15a0e4459ac980
+
+sframe_key =3D HKDF-Expand(sframe_secret,
+    "SFrame 1.0 Secret key" || 0000000000000030 || 0001, 16):
+  65f51bf13b4d4dfd1964358ee0a0c5c3
+
+sframe_salt =3D HKDF-Expand(sframe_secret,
+    "SFrame 1.0 Secret salt" || 0000000000000030 || 0001, 12):
+  70965b8dd6f1cb2d678c09e2
+
+nonce (CTR=3D0): 70965b8dd6f1cb2d678c09e2
+nonce (CTR=3D1): 70965b8dd6f1cb2d678c09e3
+```
+
+### SFrame Header Encoding
+
+```
+KID=3D48 (0x30), CTR=3D0:
+  Config byte: X=3D1 K=3D000 Y=3D0 C=3D000 =3D 0x80
+  Extended KID: 0x30
+  Header: 8030
+
+KID=3D48, CTR=3D1:
+  Config byte: X=3D1 K=3D000 Y=3D0 C=3D001 =3D 0x81
+  Extended KID: 0x30
+  Header: 8130
+```
+
+### SFrame Encryption
+
+```
+plaintext:     48656c6c6f204d61726d6f7421  ("Hello Marmot!")
+AAD (header):  8030
+key:           65f51bf13b4d4dfd1964358ee0a0c5c3
+nonce:         70965b8dd6f1cb2d678c09e2
+
+AES-128-GCM output:
+  ciphertext (13 bytes): 5e16f0a515a9ec79a2d6b0dd9a
+  auth tag (16 bytes):   49f9ea1257c4866ad383a1d2841174ac
+
+Full SFrame output (header || ciphertext || tag):
+  80305e16f0a515a9ec79a2d6b0dd9a49f9ea1257c4866ad383a1d2841174ac
+
+Total: 31 bytes (plaintext: 13, overhead: 18)
+```
+
+### KID Parsing Verification
+
+```
+KID=3D48:   epoch=3D48 & 0xF =3D 0,  leaf=3D(48>>4) & 0x3F =3D 3,  media=3D4=
+8>>10 =3D 0  =E2=9C=93
+KID=3D62:   epoch=3D62 & 0xF =3D 14, leaf=3D(62>>4) & 0x3F =3D 3,  media=3D6=
+2>>10 =3D 0  =E2=9C=93
+KID=3D1086: epoch=3D1086 & 0xF =3D 14, leaf=3D(1086>>4) & 0x3F =3D 3, media=3D=
+1086>>10 =3D 1  =E2=9C=93
+KID=3D2110: epoch=3D2110 & 0xF =3D 14, leaf=3D(2110>>4) & 0x3F =3D 3, media=3D=
+2110>>10 =3D 2  =E2=9C=93
+KID=3D1023: epoch=3D1023 & 0xF =3D 15, leaf=3D(1023>>4) & 0x3F =3D 63, media=
+=3D1023>>10 =3D 0  =E2=9C=93
+```
+
+## References
+
+- [RFC 9420: The Messaging Layer Security (MLS) Protocol](https://www.rfc-ed=
+itor.org/rfc/rfc9420)
+- [RFC 9605: Secure Frames (SFrame)](https://www.rfc-editor.org/rfc/rfc9605)=
+
+- [RFC 8445: Interactive Connectivity Establishment (ICE)](https://www.rfc-e=
+ditor.org/rfc/rfc8445)
+- [RFC 8838: Trickle ICE](https://www.rfc-editor.org/rfc/rfc8838)
+- [RFC 8828: WebRTC IP Address Handling](https://www.rfc-editor.org/rfc/rfc8=
+828)
+- [RFC 5764: DTLS-SRTP](https://www.rfc-editor.org/rfc/rfc5764)
+- [RFC 6464: Client-to-Mixer Audio Level](https://www.rfc-editor.org/rfc/rfc=
+6464)
+- [RFC 6716: Opus Audio Codec](https://www.rfc-editor.org/rfc/rfc6716)
+- [RFC 9725: WHIP](https://www.rfc-editor.org/rfc/rfc9725)
+- [W3C: WebRTC Encoded Transform](https://www.w3.org/TR/webrtc-encoded-trans=
+form/)
+- [MIP-00: Credentials & Key Packages](00.md)
+- [MIP-01: Group Construction](01.md)
+- [MIP-03: Group Messages](03.md)
+- [MIP-05: Push Notifications](05.md)
+- [NIP-59: Gift Wrap](https://github.com/nostr-protocol/nips/blob/master/59.=
+md)


### PR DESCRIPTION
Specifies privacy-preserving real-time voice and video calling within Marmot groups. Media is E2EE using SFrame with keys derived from MLS epoch exporter secret. Call signaling travels as MLS app messages. Tiered media topology scales from p2p mesh to cascaded SFU federation. New event kinds 450-454 (call signaling), 10052 (SFU advertisement). Depends on MIPs 00, 01, 03, 05. Includes test vectors and wire format constants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added MIP-06 Group Voice & Video Calling specification detailing end-to-end encrypted real-time communication with support for multiple media topologies, privacy enhancements, active speaker detection, bandwidth management, and recording capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->