### PR TITLE
MIP-01: update extension format to v2, fix TLS encoding

### DIFF
--- a/01.md
+++ b/01.md
@@ -248,10 +248,9 @@ function validate_structure(data, version) {
 
     for field in variable_fields {
         if (offset + 2 > data.length) return false
-        field_len = read_length_prefix(data, offset)
-        prefix_size = length_prefix_size(field_len)
-        if (offset + prefix_size + field_len > data.length) return false
-        offset += prefix_size + field_len
+        field_len = read_uint16_be(data[offset:offset+2])  // 2-byte length prefix
+        if (offset + 2 + field_len > data.length) return false
+        offset += 2 + field_len
     }
 
     // All known fields consumed; ignore any trailing bytes (forward compatibility)


### PR DESCRIPTION
## Summary

Updates MIP-01 to match the v2 extension format used by the [MDK reference implementation](https://github.com/marmot-protocol/mdk). The published spec described v1; MDK has shipped v2 for some time, making the two wire-incompatible.

- **admin_pubkeys/relays**: comma-separated opaque blobs → TLS vectors of individually length-prefixed elements (`AdminPubkey`/`RelayUrl` types)
- **image fields**: fixed-size (`[32]`, `[12]`) → variable-length (`<0..2^16-1>`), allowing empty encoding when no image is set
- **New field**: `image_upload_key` — cryptographically independent upload seed, separate from encryption seed
- **Version**: 1 → 2, with v1 backward compatibility notes
- **HKDF**: v2 derivation contexts (`mip01-image-encryption-v2`, `mip01-blossom-upload-v2`), seed-based key derivation
- **Validation pseudocode**: updated for all-variable-length fields, fixed strict-equality vs forward-compatibility inconsistency, explicit version 0 rejection

Closes #35, closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version 2 rollout with graceful handling of future versions and stricter creation rules.
  * Improved image handling: separate upload key and refined encryption derivation for safer uploads.

* **Refactor**
  * Group metadata encoding revised: admin and relay lists now use explicit per-item encoding and length-prefixing.

* **Bug Fixes**
  * Validation tightened to reject invalid version values and better detect malformed group data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->