### PR TITLE
MIP-00/MIP-02: Add client_id tag for multi-device KeyPackage discovery

### DIFF
--- a/00.md
+++ b/00.md
@@ -48,6 +48,7 @@ KeyPackages are typically consumed when joining groups. To handle race condition
     ["mls_extensions", "0xf2ee", "0x000a"],
     ["encoding", "base64"],
     ["i", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"],
+    ["client_id", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"],
     ["client", "MyMLSClient"],
     ["relays", "wss://relay1.com", "wss://relay2.com"],
     ["-"]
@@ -72,6 +73,9 @@ The `mls_extensions` tag includes marmot_group_data (`0xf2ee`) and last_resort (
 - **`mls_extensions`**: Array of supported non-default MLS extension IDs (see [MLS spec](https://www.rfc-editor.org/rfc/rfc9420.html#name-extensions)). Default extensions MUST NOT be listed. This signals **individual client capabilities** via `LeafNode.capabilities` in KeyPackages. Marmot implementations MUST include the `0xf2ee` extension for marmot_group_data and the `0x000a` extension for last_resort.
 - **`i`**: Hex-encoded `KeyPackageRef` for efficient relay queries (see [KeyPackageRef Tag](#keypackageref-tag) below)
 - **`relays`**: Relay URLs where this KeyPackage is published (needed for later deletion when using relay distribution)
+
+**Recommended fields:**
+- **`client_id`**: A random 32-byte hex-encoded identifier unique to a specific client installation. Generated once on first launch and persisted for the lifetime of that installation. Used for [multi-device KeyPackage discovery](#multi-device-support). Format: `["client_id", "<64-hex-char-random-id>"]`. See [Multi-Device Support](#multi-device-support) for details.
 
 **Optional fields:**
 - **`client`**: Client name to help with UX when users can't access signing keys (may be omitted for privacy). Format: `["client", "<name>"]`
@@ -235,6 +239,61 @@ When using relay-based KeyPackage distribution, users publish a `kind: 10051` ev
 }
 ```
 
+## Multi-Device Support
+
+A user may run Marmot-compatible clients on multiple devices (e.g., a phone and a laptop). Per the MLS protocol ([RFC 9750 §6.7](https://www.rfc-editor.org/rfc/rfc9750.html#section-6.7)), each device is a separate MLS client with its own signing key, KeyPackage, and leaf node in the group's ratchet tree. It is not possible to share MLS group state across devices. If a user joins a group from two devices, they occupy two separate leaf nodes, but both leaf nodes share the same Nostr identity (credential).
+
+### The Discovery Problem
+
+When inviting a user to a group, the inviter queries relays for the user's KeyPackage events (`kind: 443`). If the user has multiple devices, each device will have published one or more KeyPackages — all under the same Nostr pubkey. Without a way to distinguish which device produced which KeyPackage, the inviter cannot reliably select one KeyPackage per device.
+
+For example, if Bob has an Android phone and an iPhone, the relay might contain 5 KeyPackage events from Bob's npub (3 from Android refreshes, 2 from iOS). Naive strategies like "pick the N most recent" can fail — if Bob recently refreshed on Android twice, the two newest KeyPackages would both be from Android, and the iPhone would be excluded from the group.
+
+### The `client_id` Tag
+
+To solve this, KeyPackage events SHOULD include a `client_id` tag that uniquely identifies the client installation that produced the KeyPackage.
+
+#### Generation
+
+- The `client_id` MUST be a 32-byte random value, hex-encoded to 64 characters
+- It MUST be generated once per client installation (e.g., on first launch) using a cryptographically secure random number generator
+- It MUST be persisted locally and reused for all KeyPackage events published by that installation
+- It MUST NOT be derived from the user's Nostr identity key, device hardware identifiers, or any other linkable value
+- A fresh `client_id` SHOULD be generated if the user reinstalls the application or resets their local MLS state
+
+#### Privacy Considerations
+
+The `client_id` is a random opaque value. It does not reveal:
+- What type of device the user has (phone, laptop, etc.)
+- What client software is being used (use the optional `client` tag for that)
+- Any hardware or OS identifiers
+
+It does reveal that **a given npub has N active devices**, which is already observable once those devices join a group (each device becomes a separate leaf node visible to all group members). The `client_id` simply moves this information to the discovery phase, before the group invitation.
+
+### KeyPackage Selection for Multi-Device Users
+
+When inviting a user to a group, clients SHOULD use the following algorithm to select KeyPackages:
+
+1. **Query** all `kind: 443` events for the target user's pubkey
+2. **Group** the results by `client_id` tag value
+3. **Select** the newest KeyPackage (highest `created_at`) from each group
+4. **Create** a separate Add proposal and Welcome message for each selected KeyPackage
+
+This produces exactly one KeyPackage per device, ensuring all of the user's devices receive a Welcome message and can join the group.
+
+#### Handling Missing `client_id` Tags
+
+For backward compatibility with KeyPackages that do not include a `client_id` tag:
+
+- Each untagged KeyPackage SHOULD be treated as belonging to a unique, unknown device
+- Implementations MAY choose to select only the single most recent untagged KeyPackage, or all of them, depending on their tolerance for creating extra leaf nodes
+
+As adoption of the `client_id` tag increases, untagged KeyPackages will become rare.
+
+### Welcome Delivery for Multi-Device Users
+
+When a user has multiple devices in a group, each device receives its own Welcome message (see [MIP-02](02.md)). The `["e", <keypackage_event_id>]` tag on the Welcome event allows each device to identify which Welcome is intended for it — the device matches the tag against the KeyPackage events it has published. Devices MUST ignore Welcome messages that reference KeyPackages they did not create.
+
 ## Summary
 
 This MIP defines the foundation of Marmot's identity system:
@@ -244,7 +303,8 @@ This MIP defines the foundation of Marmot's identity system:
 1. **MLS Credentials**: Link Nostr identities to MLS signing keys
 2. **KeyPackages** (`kind: 443`): Advertise your ability to join groups (via relays or direct sharing)
 3. **Relay Lists** (`kind: 10051`): Where to find your KeyPackages (for relay-based distribution)
-4. **Signing Key Rotation**: Regular key updates for enhanced security
+4. **Multi-Device Discovery**: The `client_id` tag enables per-device KeyPackage selection
+5. **Signing Key Rotation**: Regular key updates for enhanced security
 
 ### Implementation Requirements
 
@@ -253,6 +313,10 @@ This MIP defines the foundation of Marmot's identity system:
 - KeyPackage lifecycle management with last resort support
 - Regular signing key rotation in all groups
 - Immutable credential identity validation
+
+**SHOULD implement**:
+- `client_id` tag on KeyPackage events for multi-device discovery
+- Per-device KeyPackage selection when inviting users to groups
 
 ### Extension Signaling Locations
 

--- a/02.md
+++ b/02.md
@@ -137,6 +137,17 @@ If Welcome processing fails, clients SHOULD:
 2. **Display clear errors**: Show user-friendly error messages
 3. **Log technical details**: Capture technical information for debugging
 
+### Multi-Device Considerations
+
+A user may have multiple devices, each with its own KeyPackage (see [MIP-00 Multi-Device Support](00.md#multi-device-support)). When adding such a user to a group:
+
+- The inviter MUST create a separate Welcome for each of the user's devices (one per selected KeyPackage)
+- Each Welcome references a specific KeyPackage via the `["e", <keypackage_event_id>]` tag
+- Each device identifies its own Welcome by matching the `e` tag against KeyPackages it has published
+- Devices MUST ignore Welcome messages referencing KeyPackages they did not create (e.g., KeyPackages from the user's other devices)
+
+After processing, each device occupies its own leaf node in the group. Both devices share the same Nostr identity but maintain independent MLS state.
+
 ### Common Failure Scenarios
 
 - **Signing key unavailable**: KeyPackage was created on a different device thus the secret key for the KeyPackage used to add the user to the group is not available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@
 
 ### Added
 
+- **MIP-00: Multi-device support via `client_id` tag**: Added recommended `client_id` tag to KeyPackage events (`kind: 443`) that uniquely identifies each client installation. This enables inviters to discover all of a user's devices and select exactly one KeyPackage per device when creating group invitations. Includes a new "Multi-Device Support" section with the discovery algorithm, privacy considerations, and backward compatibility guidance.
+- **MIP-02: Multi-device Welcome delivery guidance**: Added a "Multi-Device Considerations" section explaining that inviters must create a separate Welcome for each of a user's devices and how devices identify their own Welcome via the `e` tag.
+
 ### Fixed
 
 ### Removed


### PR DESCRIPTION
NOTE: this PR was created during a livestream with myself and Derek Ross. We were trying to figure out how to add multiple clients to Derek's Burrow app. This PR isn't polished and is purely meant to start a discussion. Everything after this sentence (including the MIP edits) was written by coding agent:

## Summary

Each device installation generates a random 32-byte `client_id` on first launch and includes it in every Kind:443 KeyPackage event. This allows inviters to group KeyPackages by `client_id` and select exactly one per device, solving the multi-device discovery problem.

## The Problem

When inviting a user to a group, the inviter queries relays for the user's KeyPackage events. If the user has multiple devices (e.g., Android + iOS), each device publishes KPs under the same npub. There is currently no way to distinguish which device produced which KeyPackage.

Naive strategies like "pick the N most recent" fail: if one device refreshes more frequently, all the top KPs may belong to the same device, and the other device is silently excluded from the group.

## The Solution

A new `client_id` tag on Kind:443 events:

```json
["client_id", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"]
```

The inviter's algorithm becomes:
1. Query all Kind:443 events for the target pubkey
2. Group by `client_id` tag
3. Select the newest KP per group
4. Create a separate Welcome for each

## Changes

- **MIP-00**: Added `client_id` to the example event and field explanations. New "Multi-Device Support" section covering the discovery problem, tag specification, selection algorithm, privacy considerations, and backward compatibility.
- **MIP-02**: Added "Multi-Device Considerations" section for Welcome delivery to multiple devices.
- **CHANGELOG**: Documented both additions.

## Privacy

The `client_id` is a random opaque value — it reveals nothing about device type, OS, or hardware. It does reveal that a given npub has N active devices, which is already observable once those devices join a group (each becomes a visible leaf node).

## Backward Compatibility

KPs without `client_id` are treated as belonging to unique, unknown devices. As adoption increases, untagged KPs become rare.

## Related

- Pika issue: https://github.com/ArcadeLabsInc/pika/issues/95
- Proof-of-concept test in MDK: `crates/mdk-core/tests/multi_device.rs` demonstrates the full flow including a scenario where the naive heuristic fails and the `client_id` approach succeeds.