### PR TITLE
MIP-01: update extension format to v2 with QUIC varint encoding

### DIFF
--- a/01.md
+++ b/01.md
@@ -65,39 +65,51 @@ The Marmot Group Data Extension serves several critical functions:
 
 ### TLS Serialization Requirements
 
-**CRITICAL**: This extension MUST use TLS presentation language serialization ([RFC 8446 Section 3](https://www.rfc-editor.org/rfc/rfc8446.html#section-3)) with proper length prefixes and byte alignment. Incorrect TLS serialization will cause interoperability failures.
+**CRITICAL**: This extension MUST use TLS presentation language serialization ([RFC 8446 Section 3](https://www.rfc-editor.org/rfc/rfc8446.html#section-3)) with proper length prefixes and byte alignment. All variable-length vectors use **QUIC-style variable-length integer encoding** ([RFC 9000 Section 16](https://www.rfc-editor.org/rfc/rfc9000.html#section-16)) for length prefixes, as implemented by the `tls_codec` crate (v0.4+). This means length prefix size varies based on the content length:
+
+| Content Length | Prefix Size | Format |
+|---------------|-------------|--------|
+| 0-63          | 1 byte      | `0b00xxxxxx` |
+| 64-16383      | 2 bytes     | `0b01xxxxxx xxxxxxxx` |
+| 16384+        | 4 bytes     | `0b10xxxxxx ...` |
+
+Incorrect TLS serialization will cause interoperability failures.
 
 ### Extension Fields
 
 #### Field Specifications
 
-| Field            | TLS Type                                | Length Constraints | Description |
-| ---------------- | --------------------------------------- | ------------------ | ----------- |
-| `version`        | `uint16 version`                       | Exactly 2 bytes    | Extension format version number. Current version is `1`. Implementations MUST validate version compatibility before processing extension data. |
-| `nostr_group_id` | `opaque nostr_group_id[32]`            | Exactly 32 bytes   | A 32-byte identifier for the group used in Nostr protocol operations. This value is distinct from the MLS group ID and MAY be updated over time through group proposals. This identifier is used in the `h` tags when publishing group message events to Nostr relays. MUST be cryptographically random when initially generated. |
-| `name`           | `opaque name<0..2^16-1>`               | 0-65535 bytes      | UTF-8 encoded group name. MUST be valid UTF-8. SHOULD be limited to 255 characters for practical display purposes. Empty string is permitted for unnamed groups. |
-| `description`    | `opaque description<0..2^16-1>`        | 0-65535 bytes      | UTF-8 encoded group description. MUST be valid UTF-8. SHOULD be limited to 1000 characters for practical display purposes. Empty string is permitted. |
-| `admin_pubkeys`  | `opaque admin_pubkeys<0..2^16-1>`      | 0-65535 bytes      | Array of 32-byte Nostr public keys (hex-encoded as 64-character strings, then UTF-8 encoded). Each public key MUST be a valid secp256k1 public key. Clients MUST verify admin status before processing proposals that modify group state, membership, or metadata. The array MUST NOT contain duplicate keys. At least one admin key MUST be present for most group operations. |
-| `relays`         | `opaque relays<0..2^16-1>`             | 0-65535 bytes      | Array of UTF-8 encoded WebSocket URLs for Nostr relays. Each URL MUST be a valid WebSocket URI (ws:// or wss://). URLs MUST be properly validated before use. The array SHOULD contain at least one relay URL and SHOULD NOT exceed 20 relays for practical performance. |
-| `image_hash`     | `opaque image_hash[32]`                | Exactly 32 bytes   | SHA-256 hash of the encrypted group image stored via [Blossom](https://github.com/hzrd149/blossom/tree/master) protocol. The hash identifies the encrypted blob on the storage server. May be all zeros if no image is set. |
-| `image_key`      | `opaque image_key[32]`                 | Exactly 32 bytes   | ChaCha20-Poly1305 encryption key for the group image. MUST be cryptographically random when generated. Also serves as the seed for deriving the Nostr keypair used for Blossom upload authentication (see [Image Upload Identity](#image-upload-identity)). May be all zeros if no image is set. |
-| `image_nonce`    | `opaque image_nonce[12]`               | Exactly 12 bytes   | ChaCha20-Poly1305 nonce for group image encryption. MUST be cryptographically random and unique for each image. Used with `image_key` for authenticated encryption/decryption. May be all zeros if no image is set. |
+| Field              | TLS Type                                  | Length Constraints | Description |
+| ------------------ | ----------------------------------------- | ------------------ | ----------- |
+| `version`          | `uint16 version`                         | Exactly 2 bytes    | Extension format version number. Current version is `2`. Implementations MUST validate version compatibility before processing extension data. |
+| `nostr_group_id`   | `opaque nostr_group_id[32]`              | Exactly 32 bytes   | A 32-byte identifier for the group used in Nostr protocol operations. This value is distinct from the MLS group ID and MAY be updated over time through group proposals. This identifier is used in the `h` tags when publishing group message events to Nostr relays. MUST be cryptographically random when initially generated. |
+| `name`             | `opaque name<0..2^16-1>`                 | 0-65535 bytes      | UTF-8 encoded group name. MUST be valid UTF-8. SHOULD be limited to 255 characters for practical display purposes. Empty string is permitted for unnamed groups. |
+| `description`      | `opaque description<0..2^16-1>`          | 0-65535 bytes      | UTF-8 encoded group description. MUST be valid UTF-8. SHOULD be limited to 1000 characters for practical display purposes. Empty string is permitted. |
+| `admin_pubkeys`    | `opaque admin_pubkeys<0..2^16-1>`        | 0-65535 bytes      | Variable-length vector containing concatenated raw 32-byte Nostr x-only public keys. Each public key MUST be a valid secp256k1 x-only public key. The total byte length MUST be a multiple of 32. Clients MUST verify admin status before processing proposals that modify group state, membership, or metadata. The array MUST NOT contain duplicate keys. At least one admin key MUST be present for most group operations. See [Array Encoding](#array-encoding-specifications). |
+| `relays`           | `RelayUrl relays<0..2^16-1>`             | 0-65535 bytes      | Variable-length vector of individually length-prefixed relay URLs. Each element is a UTF-8 encoded WebSocket URL with its own QUIC varint length prefix. Each URL MUST be a valid WebSocket URI (ws:// or wss://). The vector SHOULD contain at least one relay URL and SHOULD NOT exceed 20 relays. See [Array Encoding](#array-encoding-specifications). |
+| `image_hash`       | `opaque image_hash<0..32>`               | 0 or 32 bytes      | SHA-256 hash of the encrypted group image stored via [Blossom](https://github.com/hzrd149/blossom/tree/master) protocol. The hash identifies the encrypted blob on the storage server. Empty (zero-length) when no image is set; exactly 32 bytes when set. |
+| `image_key`        | `opaque image_key<0..32>`                | 0 or 32 bytes      | Image encryption seed. Used with HKDF to derive the ChaCha20-Poly1305 encryption key (see [Image Encryption](#image-encryption)). MUST be cryptographically random when generated. Empty when no image is set; exactly 32 bytes when set. |
+| `image_nonce`      | `opaque image_nonce<0..12>`              | 0 or 12 bytes      | ChaCha20-Poly1305 nonce for group image encryption. MUST be cryptographically random and unique for each image. Used with the derived encryption key for authenticated encryption/decryption. Empty when no image is set; exactly 12 bytes when set. |
+| `image_upload_key` | `opaque image_upload_key<0..32>`         | 0 or 32 bytes      | Upload seed for deriving the Nostr keypair used for Blossom upload authentication (see [Image Upload Identity](#image-upload-identity)). Cryptographically independent from `image_key`. MUST be cryptographically random when generated. Empty when no image is set; exactly 32 bytes when set. |
 
 #### TLS Structure Definition
 
 In TLS presentation language, the extension data MUST be structured as:
 
 ```tls
+opaque RelayUrl<0..2^16-1>;        // UTF-8 encoded WebSocket URL
+
 struct {
-    uint16 version;                    // Version number (current: 1)
+    uint16 version;                    // Version number (current: 2)
     opaque nostr_group_id[32];
     opaque name<0..2^16-1>;
     opaque description<0..2^16-1>;
-    opaque admin_pubkeys<0..2^16-1>;
-    opaque relays<0..2^16-1>;
-    opaque image_hash[32];
-    opaque image_key[32];
-    opaque image_nonce[12];
+    opaque admin_pubkeys<0..2^16-1>;   // Concatenated raw 32-byte x-only pubkeys
+    RelayUrl relays<0..2^16-1>;        // Vector of length-prefixed URL strings
+    opaque image_hash<0..32>;          // 0 or 32 bytes
+    opaque image_key<0..32>;           // 0 or 32 bytes (encryption seed)
+    opaque image_nonce<0..12>;         // 0 or 12 bytes
+    opaque image_upload_key<0..32>;    // 0 or 32 bytes (upload seed)
 } NostrGroupData;
 ```
 
@@ -105,65 +117,91 @@ struct {
 
 The `version` field enables forward-compatible evolution of the extension format:
 
-- **Current Version**: `1` (first versioned format)
-- **Future Versions**: Higher version numbers indicate newer formats with additional fields
-- **Forward Compatibility**: Implementations SHOULD gracefully handle unknown versions by parsing known fields
+- **Version `1`**: Initial versioned format (deprecated). Used `image_key` directly as the ChaCha20-Poly1305 encryption key and derived the upload keypair from `image_key`. Did not include `image_upload_key` field. Used hex-encoded admin pubkeys.
+- **Version `2`** (current): Uses raw 32-byte admin pubkeys. Uses `image_key` as a seed for HKDF derivation of the encryption key. Adds `image_upload_key` as a separate seed for upload keypair derivation, providing cryptographic independence between encryption and upload authentication. Variable-length image fields allow empty encoding when no image is set.
+- **Version `0`**: Reserved and MUST be rejected as invalid. Version numbering starts at 1.
+- **Future Versions**: Higher version numbers indicate newer formats with additional fields appended at the end
+- **Forward Compatibility**: Implementations SHOULD gracefully handle unknown versions by parsing known fields and ignoring unknown trailing fields
 
 ### Implementation Considerations
 
 #### Array Encoding Specifications
 
 **Admin Public Keys Array**:
-The `admin_pubkeys` field contains a comma-separated list of hex-encoded public keys:
-- Each public key: 64 hex characters (representing 32 bytes)
-- Separator: single comma character (',')
-- No spaces around commas
-- Example: `"03a1b2c3d4e5f6...,02f6e5d4c3b2a1..."`
+The `admin_pubkeys` field is a variable-length vector containing concatenated raw 32-byte x-only public keys with a single outer QUIC varint length prefix:
+- Outer length prefix: QUIC varint encoding the total byte count of all keys
+- Keys: Concatenated raw 32-byte x-only secp256k1 public keys (no per-element length prefix)
+- The total byte length MUST be a multiple of 32; divide by 32 to get the key count
+- Keys are packed sequentially with no separators or padding
+
+**Wire format example** (admin_pubkeys with two keys):
+```text
+[QUIC varint: 64][32 bytes of pubkey₁][32 bytes of pubkey₂]
+```
+
+Note: With 2 keys (64 total bytes), the outer QUIC varint prefix is 2 bytes (since 64 >= 64 threshold). With 1 key (32 bytes), the prefix is 1 byte.
 
 **Relays Array**:
-The `relays` field contains a comma-separated list of WebSocket URLs:
-- Each URL: valid WebSocket URI (ws:// or wss://)
-- Separator: single comma character (',')
-- No spaces around commas
-- Example: `"wss://relay1.example.com,wss://relay2.example.com"`
+The `relays` field is a variable-length vector of individually length-prefixed relay URLs:
+- Outer length prefix: QUIC varint encoding the total byte count of all inner elements (including their prefixes)
+- Each element: QUIC varint length prefix for that URL's byte count, followed by the UTF-8 encoded URL bytes
+- Each URL MUST be a valid WebSocket URI (ws:// or wss://)
+
+**Wire format example** (relays with two URLs):
+```text
+[QUIC varint: total inner bytes][QUIC varint: url₁ len][url₁ bytes][QUIC varint: url₂ len][url₂ bytes]
+```
+
+#### Image Encryption
+
+The group image encryption uses ChaCha20-Poly1305 with key material derived via HKDF from seeds stored in the extension.
+
+**Encryption** (v2): When encrypting a group image:
+
+```pseudocode
+image_key = random(32)              // Cryptographically random encryption seed
+image_nonce = random(12)            // Cryptographically random nonce
+image_upload_key = random(32)       // Cryptographically random upload seed
+
+// Derive encryption key from seed using HKDF (Extract then Expand)
+prk = HKDF-Extract(salt=None, IKM=image_key)
+encryption_key = HKDF-Expand(prk, "mip01-image-encryption-v2", 32)
+
+encrypted_image = ChaCha20-Poly1305.encrypt(encryption_key, image_nonce, image_data)
+```
+
+The `image_key` field stores the seed, not the encryption key directly. This provides domain separation between the stored seed and the derived encryption key.
 
 #### Image Upload Identity
 
-The group image encryption uses ChaCha20-Poly1305 with a deterministic Nostr keypair derivation for Blossom authentication. This design enables automatic cleanup of old images when updating.
+The Nostr keypair for Blossom upload authentication MUST be deterministically derived from the `image_upload_key` seed:
 
-**Encryption**: When encrypting a group image:
-
-```
-image_key = random(32)          // Cryptographically random key
-image_nonce = random(12)        // Cryptographically random nonce
-encrypted_image = ChaCha20-Poly1305.encrypt(image_key, image_nonce, image_data)
-```
-
-**Upload Authentication**: The Nostr keypair for Blossom upload authentication MUST be deterministically derived from the `image_key`:
-
-```
-upload_secret = HKDF-Expand(image_key, "mip01-blossom-upload-v1", 32)
+```pseudocode
+prk = HKDF-Extract(salt=None, IKM=image_upload_key)
+upload_secret = HKDF-Expand(prk, "mip01-blossom-upload-v2", 32)
 upload_keypair = secp256k1_keypair_from_secret(upload_secret)
 ```
 
-This derivation provides domain separation between the encryption key and the signing key, while ensuring that anyone with the `image_key` can derive the upload keypair for cleanup purposes.
+The `image_upload_key` is cryptographically independent from `image_key`, ensuring that the upload authentication keypair is fully separated from the encryption key material.
 
 **Update and Cleanup Workflow**:
 
 When an admin updates the group image:
 
-1. **Generate new keys**: Create new random `image_key` (32 bytes) and `image_nonce` (12 bytes)
-2. **Encrypt new image**: Use ChaCha20-Poly1305 to encrypt the new group image
-3. **Derive upload keypair**: Compute `upload_secret = HKDF-Expand(new_image_key, "mip01-blossom-upload-v1", 32)` and derive the Nostr keypair
-4. **Upload to Blossom**: Upload the encrypted image using the derived keypair for authentication, obtaining `new_image_hash = SHA256(encrypted_image)`
-5. **Update extension**: Commit an MLS proposal updating `image_hash`, `image_key`, and `image_nonce` fields
-6. **Cleanup old image**: After successful commit, derive the previous upload keypair from `old_image_key` and request deletion of the old image blob from Blossom using the derived keypair for authentication
+1. **Generate new seeds**: Create new random `image_key` (32 bytes), `image_nonce` (12 bytes), and `image_upload_key` (32 bytes)
+2. **Derive encryption key**: Compute `prk = HKDF-Extract(salt=None, IKM=image_key)`, then `encryption_key = HKDF-Expand(prk, "mip01-image-encryption-v2", 32)`
+3. **Encrypt new image**: Use ChaCha20-Poly1305 to encrypt the new group image with the derived key
+4. **Derive upload keypair**: Compute `prk = HKDF-Extract(salt=None, IKM=image_upload_key)`, then `upload_secret = HKDF-Expand(prk, "mip01-blossom-upload-v2", 32)` and derive the Nostr keypair
+5. **Upload to Blossom**: Upload the encrypted image using the derived keypair for authentication, obtaining `new_image_hash = SHA256(encrypted_image)`
+6. **Update extension**: Commit an MLS proposal updating `image_hash`, `image_key`, `image_nonce`, and `image_upload_key` fields
+7. **Cleanup old image**: After successful commit, derive the previous upload keypair from `old_image_upload_key` and request deletion of the old image blob from Blossom
 
-**Security Properties**:
+**Security Properties** (see [threat_model.md](threat_model.md) for threat assumptions and context):
 
 - **Encryption independence**: Image encryption keys persist across MLS epochs (unlike chat media in MIP-04 which uses rotating exporter secrets)
-- **Cleanup capability**: Any admin who has access to a previous `image_key` can derive the upload keypair to delete that image blob
-- **Domain separation**: HKDF-Expand ensures the upload secret is cryptographically independent from the encryption key
+- **Cleanup capability**: Any admin who has access to a previous `image_upload_key` can derive the upload keypair to delete that image blob
+- **Domain separation**: HKDF with distinct context strings ensures cryptographic independence between the encryption key, the upload secret, and the stored seeds
+- **Key independence**: `image_key` and `image_upload_key` are independently random, so compromise of one does not affect the other
 - **Forward compatibility**: Old members who leave cannot access new group images (they don't receive updated extension data)
 
 #### Extension Lifecycle Management
@@ -177,13 +215,20 @@ When an admin updates the group image:
 **Version Detection**: Implementations MUST validate the extension format version:
 
 ```pseudocode
+MAX_SUPPORTED_VERSION = 2
+
 function detect_version(extension_data) {
     if (extension_data.length < 2) {
         return ERROR_INVALID_EXTENSION
     }
 
-    // Read version field
+    // Read version field (uint16, big-endian)
     version = read_uint16_be(extension_data[0:2])
+
+    // Version 0 is reserved and invalid
+    if (version == 0) {
+        return ERROR_INVALID_EXTENSION
+    }
 
     // Validate known versions
     if (version >= 1 && version <= MAX_SUPPORTED_VERSION) {
@@ -195,53 +240,45 @@ function detect_version(extension_data) {
 
     // Handle future versions with forward compatibility
     if (version > MAX_SUPPORTED_VERSION) {
-        if (validate_structure(extension_data, version)) {
-            return VERSION_UNKNOWN_FUTURE
-        }
+        log_warning("Unknown extension version, attempting forward compatibility")
+        return VERSION_UNKNOWN_FUTURE
     }
 
     return ERROR_INVALID_EXTENSION
 }
 
 function validate_structure(data, version) {
-    // Minimum size: version(2) + nostr_group_id(32) + name(2+0) + desc(2+0) +
-    //               admins(2+0) + relays(2+0) + image_hash(32) + image_key(32) + image_nonce(12)
-    MIN_SIZE = 2 + 32 + 2 + 2 + 2 + 2 + 32 + 32 + 12  // = 118 bytes
+    // All variable-length fields use QUIC varint length-prefixed encoding.
+    // Minimum size with all variable fields empty (1-byte QUIC varint prefix each):
+    //   version(2) + nostr_group_id(32) + name(1+0) + description(1+0) +
+    //   admin_pubkeys(1+0) + relays(1+0) + image_hash(1+0) + image_key(1+0) +
+    //   image_nonce(1+0) + image_upload_key(1+0)
+    MIN_SIZE = 2 + 32 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1  // = 42 bytes
 
     if (data.length < MIN_SIZE) return false
 
-    // Validate that variable-length fields have reasonable lengths
     offset = 2 + 32  // Skip version and nostr_group_id
 
-    // Validate name length
-    name_len = read_uint16_be(data[offset:offset+2])
-    if (offset + 2 + name_len > data.length) return false
-    offset += 2 + name_len
+    // Validate each variable-length field in order
+    variable_fields = [
+        "name", "description", "admin_pubkeys", "relays",
+        "image_hash", "image_key", "image_nonce", "image_upload_key"
+    ]
 
-    // Validate description length
-    desc_len = read_uint16_be(data[offset:offset+2])
-    if (offset + 2 + desc_len > data.length) return false
-    offset += 2 + desc_len
+    for field in variable_fields {
+        (field_len, prefix_size) = read_quic_varint(data, offset)
+        if (offset + prefix_size + field_len > data.length) return false
+        offset += prefix_size + field_len
+    }
 
-    // Validate admin_pubkeys length
-    admin_len = read_uint16_be(data[offset:offset+2])
-    if (offset + 2 + admin_len > data.length) return false
-    offset += 2 + admin_len
-
-    // Validate relays length
-    relays_len = read_uint16_be(data[offset:offset+2])
-    if (offset + 2 + relays_len > data.length) return false
-    offset += 2 + relays_len
-
-    // Check remaining fixed fields fit
-    REMAINING_FIXED = 32 + 32 + 12  // image_hash + image_key + image_nonce
-    return (offset + REMAINING_FIXED == data.length)
+    // All known fields consumed; ignore any trailing bytes (forward compatibility)
+    return true
 }
 ```
 
-**Forward Compatibility**: When encountering unknown future versions:
-- Parse known fields in order (version, nostr_group_id, name, description, admin_pubkeys, relays, image_hash, image_key, image_nonce)
-- Ignore additional unknown fields
+**Forward Compatibility**: The extension format is append-only: future versions may only add new fields at the end. Parsers MUST parse fields in the documented order. When encountering unknown future versions:
+- Parse known fields in order (version, nostr_group_id, name, description, admin_pubkeys, relays, image_hash, image_key, image_nonce, image_upload_key)
+- Ignore any unknown trailing fields beyond the last known field
 - Continue normal operation with available data
 - Log warning about unknown version for debugging
 
@@ -250,13 +287,16 @@ function validate_structure(data, version) {
 **Requirements**:
 - Register extension `0xF2EE` as required capability in both individual capabilities (`LeafNode.capabilities`) and group requirements (`GroupContext.extensions`)
 - Use exact TLS structure definition provided
+- Use QUIC-style variable-length integer encoding for all vector length prefixes
 - Implement version detection algorithm for forward compatibility
 - Validate UTF-8 strings, public keys, and URLs
-- Parse arrays as comma-separated (no spaces)
+- Serialize `admin_pubkeys` as concatenated raw 32-byte x-only public keys (no per-element prefix)
+- Serialize `relays` as a vector of individually QUIC varint length-prefixed URL strings
 - Verify admin permissions for all extension updates including version changes
 
 **Version-Specific Implementation**:
-- **New Groups**: MUST create with version `1` format
+- **New Groups**: MUST create with version `2` format
+- **Version 1 Support**: Implementations SHOULD support reading version 1 extensions for backward compatibility. In version 1, `image_key` is used directly as the encryption key (not as an HKDF seed), `image_upload_key` is absent (the upload keypair is derived from `image_key` using context `"mip01-blossom-upload-v1"`), and admin pubkeys are hex-encoded strings
 - **Future Versions**: SHOULD implement forward compatibility for unknown versions
 - **Error Handling**: MUST gracefully handle version mismatches with clear error messages
 
@@ -287,5 +327,5 @@ This MIP defines the foundation for creating secure, Nostr-integrated groups:
 - Admin verification for all extension updates including version changes
 - Compatibility checking before group creation
 - Private MLS group IDs (never publish to relays)
-- ChaCha20-Poly1305 encryption for group images
-- Deterministic upload keypair derivation using `HKDF-Expand(image_key, "mip01-blossom-upload-v1", 32)` for Blossom authentication and cleanup
+- ChaCha20-Poly1305 encryption for group images with HKDF key derivation: `HKDF-Extract(salt=None, IKM=image_key)` then `HKDF-Expand(prk, "mip01-image-encryption-v2", 32)`
+- Deterministic upload keypair derivation using `HKDF-Extract(salt=None, IKM=image_upload_key)` then `HKDF-Expand(prk, "mip01-blossom-upload-v2", 32)` for Blossom authentication and cleanup

--- a/data_flows.md
+++ b/data_flows.md
@@ -102,7 +102,7 @@ sequenceDiagram
 
     A->>A: Build Marmot Group<br/>Data Extension
 
-    Note over A: Extension fields:<br/>- version: 1<br/>- nostr_group_id (random 32 bytes)<br/>- name, description<br/>- admin_pubkeys (TLS array)<br/>- relays (TLS array)<br/>- image fields (optional)
+    Note over A: Extension fields:<br/>- version: 2<br/>- nostr_group_id (random 32 bytes)<br/>- name, description<br/>- admin_pubkeys (raw 32-byte keys)<br/>- relays (length-prefixed URLs)<br/>- image fields (optional)
 
     A->>MLS: Add extension to<br/>GroupContext
 

--- a/threat_model.md
+++ b/threat_model.md
@@ -1410,7 +1410,7 @@ Common mistakes that developers should avoid when implementing Marmot:
 
 **Consequences**: Decryption failures, inability to decrypt messages from other implementations.
 
-**Solution**: Use exact context strings from specification. For [MIP-04](04.md): `"mip04-v1" || 0x00 || file_hash || 0x00 || mime_type || 0x00 || filename || 0x00 || "key"`. Test cross-implementation compatibility.
+**Solution**: Use exact context strings from specification. For [MIP-04](04.md): `"mip04-v2" || 0x00 || file_hash || 0x00 || mime_type || 0x00 || filename || 0x00 || "key"`. Test cross-implementation compatibility.
 
 #### 3.1.8 Extension Version Handling
 


### PR DESCRIPTION
## Summary

Updates MIP-01 to v2 extension format, aligning the spec with the MDK reference implementation. This supersedes PR #37 which had unresolved review feedback around encoding specifics.

### Changes

**Wire format (01.md):**
- **Version**: Bumped from 1 to 2, with v1 backward compat notes and v0 rejection
- **admin_pubkeys**: Changed from hex-encoded comma-separated strings to concatenated raw 32-byte x-only public keys (single outer QUIC varint prefix, no per-element prefix)
- **Length prefixes**: Documented QUIC-style variable-length integer encoding (RFC 9000 Section 16) for all vectors, matching `tls_codec` 0.4+
- **image_upload_key**: New field — cryptographically independent upload seed, separate from encryption seed
- **image_key**: Now an HKDF seed rather than a direct encryption key
- **Image field bounds**: Tightened from `<0..2^16-1>` to `<0..32>` / `<0..12>` matching actual data sizes
- **HKDF**: Full Extract+Expand flow documented for both `mip01-image-encryption-v2` and `mip01-blossom-upload-v2`
- **Validation pseudocode**: Rewritten for QUIC varint parsing, MIN_SIZE corrected to 42 bytes

**Cross-references:**
- **data_flows.md**: Updated extension version from 1 to 2, updated field labels
- **threat_model.md**: Fixed HKDF context example from `mip04-v1` to `mip04-v2`

### MDK impact

The corresponding MDK changes are isolated to 4 locations in `crates/mdk-core/src/extension/types.rs`:
1. Struct field: `Vec<Vec<u8>>` -> `Vec<[u8; 32]>`
2. `as_raw()`: `pk.to_hex().into_bytes()` -> `*pk.as_bytes()`
3. `from_raw()`: Remove hex decode, use `PublicKey::from_byte_array()`
4. Tests: Update raw struct construction

No migration needed (still in breaking changes phase).

Closes #35, closes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Marmot Group Data Extension specification to version 2
  * Added new image_upload_key field to extension specification
  * Updated field serialization format and definitions for admin_pubkeys, relays, and image-related fields
  * Enhanced security and forward compatibility guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->