### PR TITLE
feat: shared group signing key for anti-spam protection

### DIFF
--- a/01.md
+++ b/01.md
@@ -81,8 +81,8 @@ Incorrect TLS serialization will cause interoperability failures.
 
 | Field              | TLS Type                                  | Length Constraints | Description |
 | ------------------ | ----------------------------------------- | ------------------ | ----------- |
-| `version`          | `uint16 version`                         | Exactly 2 bytes    | Extension format version number. Current version is `2`. Implementations MUST validate version compatibility before processing extension data. |
-| `nostr_group_id`   | `opaque nostr_group_id[32]`              | Exactly 32 bytes   | A 32-byte identifier for the group used in Nostr protocol operations. This value is distinct from the MLS group ID and MAY be updated over time through group proposals. This identifier is used in the `h` tags when publishing group message events to Nostr relays. MUST be cryptographically random when initially generated. |
+| `version`          | `uint16 version`                         | Exactly 2 bytes    | Extension format version number. Current version is `3`. Implementations MUST validate version compatibility before processing extension data. |
+| `nostr_group_id`   | `opaque nostr_group_id[32]`              | Exactly 32 bytes   | A 32-byte identifier for the group used internally for local storage and cross-referencing. This value is distinct from the MLS group ID and MAY be updated over time through group proposals. MUST be cryptographically random when initially generated. Not used in any Nostr event tag (Group Events are identified by the `group_pubkey` derived from `group_signing_key`). |
 | `name`             | `opaque name<0..2^16-1>`                 | 0-65535 bytes      | UTF-8 encoded group name. MUST be valid UTF-8. SHOULD be limited to 255 characters for practical display purposes. Empty string is permitted for unnamed groups. |
 | `description`      | `opaque description<0..2^16-1>`          | 0-65535 bytes      | UTF-8 encoded group description. MUST be valid UTF-8. SHOULD be limited to 1000 characters for practical display purposes. Empty string is permitted. |
 | `admin_pubkeys`    | `opaque admin_pubkeys<0..2^16-1>`        | 0-65535 bytes      | Variable-length vector containing concatenated raw 32-byte Nostr x-only public keys. Each public key MUST be a valid secp256k1 x-only public key. The total byte length MUST be a multiple of 32. Clients MUST verify admin status before processing proposals that modify group state, membership, or metadata. The array MUST NOT contain duplicate keys. At least one admin key MUST be present for most group operations. See [Array Encoding](#array-encoding-specifications). |
@@ -91,6 +91,7 @@ Incorrect TLS serialization will cause interoperability failures.
 | `image_key`        | `opaque image_key<0..32>`                | 0 or 32 bytes      | Image encryption seed. Used with HKDF to derive the ChaCha20-Poly1305 encryption key (see [Image Encryption](#image-encryption)). MUST be cryptographically random when generated. Empty when no image is set; exactly 32 bytes when set. |
 | `image_nonce`      | `opaque image_nonce<0..12>`              | 0 or 12 bytes      | ChaCha20-Poly1305 nonce for group image encryption. MUST be cryptographically random and unique for each image. Used with the derived encryption key for authenticated encryption/decryption. Empty when no image is set; exactly 12 bytes when set. |
 | `image_upload_key` | `opaque image_upload_key<0..32>`         | 0 or 32 bytes      | Upload seed for deriving the Nostr keypair used for Blossom upload authentication (see [Image Upload Identity](#image-upload-identity)). Cryptographically independent from `image_key`. MUST be cryptographically random when generated. Empty when no image is set; exactly 32 bytes when set. |
+| `group_signing_key` | `opaque group_signing_key<0..32>`       | 0 or 32 bytes      | secp256k1 private key used for signing kind: 445 Group Events. When present, all Group Events are signed with this key and clients subscribe by `authors` filter instead of `#h` tag (see [MIP-03](03.md)). MUST be a valid BIP340-compatible private key (1 <= d < secp256k1 curve order). MUST be cryptographically random when generated. Empty (0 bytes) for legacy groups; exactly 32 bytes for new groups. |
 
 #### TLS Structure Definition
 
@@ -100,7 +101,7 @@ In TLS presentation language, the extension data MUST be structured as:
 opaque RelayUrl<0..2^16-1>;        // UTF-8 encoded WebSocket URL
 
 struct {
-    uint16 version;                    // Version number (current: 2)
+    uint16 version;                    // Version number (current: 3)
     opaque nostr_group_id[32];
     opaque name<0..2^16-1>;
     opaque description<0..2^16-1>;
@@ -110,6 +111,7 @@ struct {
     opaque image_key<0..32>;           // 0 or 32 bytes (encryption seed)
     opaque image_nonce<0..12>;         // 0 or 12 bytes
     opaque image_upload_key<0..32>;    // 0 or 32 bytes (upload seed)
+    opaque group_signing_key<0..32>;   // 0 or 32 bytes (anti-spam signing key)
 } NostrGroupData;
 ```
 
@@ -118,7 +120,8 @@ struct {
 The `version` field enables forward-compatible evolution of the extension format:
 
 - **Version `1`**: Initial versioned format (deprecated). Used `image_key` directly as the ChaCha20-Poly1305 encryption key and derived the upload keypair from `image_key`. Did not include `image_upload_key` field. Used hex-encoded admin pubkeys.
-- **Version `2`** (current): Uses raw 32-byte admin pubkeys. Uses `image_key` as a seed for HKDF derivation of the encryption key. Adds `image_upload_key` as a separate seed for upload keypair derivation, providing cryptographic independence between encryption and upload authentication. Variable-length image fields allow empty encoding when no image is set.
+- **Version `2`**: Uses raw 32-byte admin pubkeys. Uses `image_key` as a seed for HKDF derivation of the encryption key. Adds `image_upload_key` as a separate seed for upload keypair derivation, providing cryptographic independence between encryption and upload authentication. Variable-length image fields allow empty encoding when no image is set.
+- **Version `3`** (current): Adds `group_signing_key` field for anti-spam protection. When present, Group Events (kind: 445) are signed with this shared key and clients subscribe by `authors` filter instead of `#h` tag, preventing non-members from publishing spam events to the group. See [MIP-03](03.md) for signing and subscription details.
 - **Version `0`**: Reserved and MUST be rejected as invalid. Version numbering starts at 1.
 - **Future Versions**: Higher version numbers indicate newer formats with additional fields appended at the end
 - **Forward Compatibility**: Implementations SHOULD gracefully handle unknown versions by parsing known fields and ignoring unknown trailing fields
@@ -204,6 +207,22 @@ When an admin updates the group image:
 - **Key independence**: `image_key` and `image_upload_key` are independently random, so compromise of one does not affect the other
 - **Forward compatibility**: Old members who leave cannot access new group images (they don't receive updated extension data)
 
+#### Group Signing Key
+
+The `group_signing_key` enables anti-spam protection for Group Events (kind: 445). When present, all group members sign Group Events with this shared key instead of ephemeral keypairs. Clients subscribe using `{ authors: [group_pubkey], kinds: [445] }` instead of `{ kinds: [445], "#h": [nostr_group_id] }`. Relays reject events with invalid signatures for the group pubkey, preventing non-members from publishing spam events to the group.
+
+**Generation**: When creating a new group, the admin MUST generate a cryptographically random 32-byte value. The value MUST be a valid secp256k1 private key (1 <= d < n, where n is the secp256k1 curve order). Implementations MUST use [BIP340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) Schnorr signatures for all events signed with this key.
+
+**Distribution**: The key is part of the MLS group state via this extension. New members receive it in the Welcome message. Existing members receive updates via Commits that modify the extension.
+
+**Rotation**: Admins SHOULD rotate the `group_signing_key` when removing a member from the group. Admins MAY rotate periodically or when the key is suspected compromised. Rotation follows the standard Proposal/Commit flow. After rotation, clients MUST update their relay subscription to include the new `group_pubkey`. Clients SHOULD temporarily subscribe to both old and new pubkeys during the transition.
+
+**NIP-09 / NIP-62 defense**: Because all members share the signing key, any member can create a valid [NIP-09](https://github.com/nostr-protocol/nips/blob/master/09.md) deletion request or [NIP-62](https://github.com/nostr-protocol/nips/blob/master/62.md) vanish request for other members' events. To mitigate this:
+
+- Clients MUST NOT honor NIP-09 (kind: 5) deletion events that reference kind: 445 events
+- Clients MUST NOT issue NIP-09 or NIP-62 events using the `group_signing_key`
+- Clients SHOULD monitor for kind: 5 and kind: 62 events from the group pubkey and alert users when detected (the individual sender cannot be identified since all members share the key)
+
 #### Extension Lifecycle Management
 
 **Creation**: When creating a new group, this extension MUST be populated with initial values and included in the group's required capabilities.
@@ -215,7 +234,7 @@ When an admin updates the group image:
 **Version Detection**: Implementations MUST validate the extension format version:
 
 ```pseudocode
-MAX_SUPPORTED_VERSION = 2
+MAX_SUPPORTED_VERSION = 3
 
 function detect_version(extension_data) {
     if (extension_data.length < 2) {
@@ -252,8 +271,8 @@ function validate_structure(data, version) {
     // Minimum size with all variable fields empty (1-byte QUIC varint prefix each):
     //   version(2) + nostr_group_id(32) + name(1+0) + description(1+0) +
     //   admin_pubkeys(1+0) + relays(1+0) + image_hash(1+0) + image_key(1+0) +
-    //   image_nonce(1+0) + image_upload_key(1+0)
-    MIN_SIZE = 2 + 32 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1  // = 42 bytes
+    //   image_nonce(1+0) + image_upload_key(1+0) + group_signing_key(1+0)
+    MIN_SIZE = 2 + 32 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1  // = 43 bytes
 
     if (data.length < MIN_SIZE) return false
 
@@ -262,7 +281,8 @@ function validate_structure(data, version) {
     // Validate each variable-length field in order
     variable_fields = [
         "name", "description", "admin_pubkeys", "relays",
-        "image_hash", "image_key", "image_nonce", "image_upload_key"
+        "image_hash", "image_key", "image_nonce", "image_upload_key",
+        "group_signing_key"
     ]
 
     for field in variable_fields {
@@ -277,7 +297,7 @@ function validate_structure(data, version) {
 ```
 
 **Forward Compatibility**: The extension format is append-only: future versions may only add new fields at the end. Parsers MUST parse fields in the documented order. When encountering unknown future versions:
-- Parse known fields in order (version, nostr_group_id, name, description, admin_pubkeys, relays, image_hash, image_key, image_nonce, image_upload_key)
+- Parse known fields in order (version, nostr_group_id, name, description, admin_pubkeys, relays, image_hash, image_key, image_nonce, image_upload_key, group_signing_key)
 - Ignore any unknown trailing fields beyond the last known field
 - Continue normal operation with available data
 - Log warning about unknown version for debugging
@@ -295,7 +315,7 @@ function validate_structure(data, version) {
 - Verify admin permissions for all extension updates including version changes
 
 **Version-Specific Implementation**:
-- **New Groups**: MUST create with version `2` format
+- **New Groups**: MUST create with version `3` format
 - **Version 1 Support**: Implementations SHOULD support reading version 1 extensions for backward compatibility. In version 1, `image_key` is used directly as the encryption key (not as an HKDF seed), `image_upload_key` is absent (the upload keypair is derived from `image_key` using context `"mip01-blossom-upload-v1"`), and admin pubkeys are hex-encoded strings
 - **Future Versions**: SHOULD implement forward compatibility for unknown versions
 - **Error Handling**: MUST gracefully handle version mismatches with clear error messages

--- a/03.md
+++ b/03.md
@@ -10,9 +10,11 @@ This document defines Group Events (`kind: 445`) that enable secure group commun
 
 Group Events enable secure group communication through encrypted control messages (`Proposal` and `Commit`) and application messages (chat, reactions) with metadata protection.
 
-## Privacy Protection
+## Privacy and Anti-Spam Protection
 
-Group Events use ephemeral keypairs and encrypted content to protect member identities and prevent group size analysis by observers.
+Group Events use a shared group signing key and encrypted content to protect member identities and prevent spam from non-members. The group signing key is stored in the Marmot Group Data Extension (see [MIP-01](01.md)) and is known only to current group members. All members sign Group Events with this shared key, so relay observers see a single pubkey per group and cannot distinguish individual senders.
+
+Because the signing key is shared, non-members cannot produce valid signatures for the group pubkey. Relays reject events with invalid signatures before delivery, providing relay-level spam prevention.
 
 ## Group Event Structure
 
@@ -21,20 +23,29 @@ Group Events use ephemeral keypairs and encrypted content to protect member iden
   "id": "ghi789...",
   "kind": 445,
   "created_at": 1693876700,
-  "pubkey": "03b2c4d6e8f0a1b3c5d7e9f1a3b5c7d9e1f3a5b7c9d1e3f5a7b9c1d3e5f7a9b1c3",
+  "pubkey": "<group_pubkey>",
   "content": "a1b2c3d4e5f6...",
-  "tags": [
-    ["h", "group_id_from_nostr_extension"]
-  ],
-  "sig": "506070809..."
+  "tags": [],
+  "sig": "<sig_by_group_signing_key>"
 }
 ```
 
 ### Field Details
 
 - **`content`**: Serialized [`MLSMessage`](https://www.rfc-editor.org/rfc/rfc9420.html#section-6-4) encrypted with [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md)
-- **`pubkey`**: Ephemeral public key (different for each Group Event)
-- **`h` tag**: Group ID from the Marmot Group Data Extension
+- **`pubkey`**: Public key derived from the `group_signing_key` in the Marmot Group Data Extension. The same pubkey is used by all group members.
+- **`sig`**: Signed with the `group_signing_key` using [BIP340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) Schnorr signatures
+- **`tags`**: Empty. Group Events do not include `h` tags or other group identifiers.
+
+### Subscription Filter
+
+Clients subscribe to group messages using the `authors` filter:
+
+```json
+{ "kinds": [445], "authors": ["<group_pubkey>"] }
+```
+
+The `authors` filter is a first-class [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md) field, indexed by all major relay implementations. Since the `group_pubkey` is stable across MLS epochs, clients maintain a single subscription per group. After an admin-initiated key rotation (see [MIP-01](01.md)), clients add the new pubkey and MAY drop the old one after a grace period.
 
 ## Encryption Details
 
@@ -43,7 +54,7 @@ Group Events use ephemeral keypairs and encrypted content to protect member iden
 1. **Get group secret**: Use the MLS `exporter_secret` from the current group epoch
 2. **Generate keypair**: Create a Nostr keypair using the `exporter_secret` as the private key
 3. **Apply NIP-44**: Encrypt the MLSMessage using the standard NIP-44 scheme. However, instead of using the sender and receiver's keys to derive a `conversation_key`, the NIP-44 encryption is done using a Nostr keypair generated from the MLS [`exporter_secret`](https://www.rfc-editor.org/rfc/rfc9420.html#section-8.5) to calculate the `conversation_key` value. Use the raw 32-byte `exporter_secret` as the secp256k1 private key (the sender key), derive the corresponding public key (used as the receiver key), and then proceed with the standard NIP-44 scheme to encrypt and decrypt messages.
-4. **Publish**: Publish the event to relays using a completely separate ephemeral keypair. This is NOT the same keypair you created in step 2.
+4. **Sign and publish**: Sign the event with the `group_signing_key` from the Marmot Group Data Extension using BIP340 Schnorr signatures, setting the `pubkey` field to the corresponding public key. Publish to relays.
 
 ## Proposal and Commit Messages
 
@@ -154,7 +165,7 @@ This approach provides the best of both worlds:
 
 **Prevent leaks**:
 - Inner events MUST remain **unsigned** (no `sig` field)
-- MUST NOT include `h` tags or other group identifiers
+- MUST NOT include group identifiers in tags
 - This ensures leaked events cannot be published to public relays
 
 ### Example Flow
@@ -181,7 +192,9 @@ This approach provides the best of both worlds:
 - Self-update Commit validation (must contain only sender's own Update proposal)
 - Key generation from `exporter_secret` with NIP-44 encryption
 - Identity verification for inner events (unsigned to prevent leaks)
-- Ephemeral keypairs (never reuse) for privacy protection
+- Group signing key for all kind: 445 events (see [MIP-01](01.md))
+- BIP340 Schnorr signatures for all Group Events
+- `authors`-based subscription filter (not `#h` tag)
 
 ### Group Hygiene
 

--- a/threat_model.md
+++ b/threat_model.md
@@ -216,12 +216,12 @@ Network observers include entities that can capture packets between clients and 
 
 #### T.1.4 - Application Message Spam
 
-- **Description**: Attackers publish kind: 445 events with valid-looking `h` tags for known groups but invalid ciphertexts.
-- **Impact**: Clients must download and attempt decryption before detecting invalidity, wasting resources.
+- **Description**: Attackers attempt to publish kind: 445 events targeting a group.
+- **Impact**: Without the shared group signing key, attackers cannot produce valid signatures for the group pubkey. Relays reject events with invalid signatures before delivery.
 - **Countermeasures**:
-  - Client-side filtering based on event signatures
-  - Use multiple `nostr_group_id` values per group to distribute attack surface
-  - Rotate group IDs periodically to limit exposure
+  - Group signing key (see [MIP-01](01.md)): all Group Events are signed with a shared key known only to group members, and clients subscribe by `authors` filter instead of `#h` tag
+  - Relays reject events with invalid signatures at ingestion, preventing delivery to group members
+  - Admin-initiated key rotation after member removal prevents removed members from signing new events
 
 ### 2.2 Relay Operators
 
@@ -827,12 +827,22 @@ Various DoS vectors exist that can degrade service quality or exhaust resources.
 
 #### T.10.2 - Application Message Spam
 
-- **Description**: Invalid kind: 445 events with valid-looking `h` tags for known groups but invalid ciphertexts.
-- **Impact**: Decryption attempts waste resources.
+- **Description**: Attackers attempt to publish kind: 445 events targeting a group.
+- **Impact**: Without the shared group signing key, attackers cannot produce valid signatures for the group pubkey. Relays reject events with invalid signatures before delivery.
 - **Countermeasures**:
-  - Client-side filtering based on event signatures
-  - Use multiple `nostr_group_id` values per group to distribute attack surface
-  - Rotate group IDs monthly to limit targeting (See also T.1.4)
+  - Group signing key (see [MIP-01](01.md)): cryptographic exclusion of non-members from publishing to the group
+  - `authors`-based subscription replaces `#h` tag subscription, so relays filter at the signature level
+  - See also T.1.4
+
+#### T.10.2.1 - NIP-09 Deletion by Group Members
+
+- **Description**: Because all group members share the signing key, any member can create a valid [NIP-09](https://github.com/nostr-protocol/nips/blob/master/09.md) deletion request (kind: 5) or [NIP-62](https://github.com/nostr-protocol/nips/blob/master/62.md) vanish request for other members' kind: 445 events. This capability does not exist with ephemeral keypairs.
+- **Impact**: A malicious insider can request deletion of other members' messages from relays. The threat is bounded: the attacker must be a current group member, the attack is observable (kind: 5 events are public, though the individual sender cannot be identified since all members share the key), client-side caching preserves events locally, and multi-relay redundancy provides resilience.
+- **Countermeasures**:
+  - Clients MUST NOT honor NIP-09 deletion events that reference kind: 445 events
+  - Clients MUST NOT issue NIP-09 or NIP-62 events using the `group_signing_key`
+  - Clients SHOULD monitor for kind: 5 and kind: 62 events from the group pubkey and alert users when detected (the individual sender cannot be identified)
+  - Groups SHOULD use at least 3 relays for redundancy
 
 #### T.10.3 - Invalid Key Package Spam
 


### PR DESCRIPTION
## Problem

Group Events (kind: 445) are currently signed with ephemeral keypairs and routed via an `h` tag containing the `nostr_group_id`. Anyone who observes this tag on a relay can publish kind:445 events targeting that group. These events pass relay validation (valid Nostr signature from the ephemeral key) and arrive at group members' clients, which must download and attempt NIP-44 decryption before detecting they are invalid.

The threat model acknowledges this as an open vulnerability (T.1.4, T.10.2) with only weak mitigations (client-side filtering, rotating group IDs).

## Proposed approach

Replace ephemeral keypairs and `h` tag routing with a **shared group signing key** stored in the Marmot Group Data Extension.

- Group creator generates a random secp256k1 private key at group creation
- The key is stored in a new `group_signing_key` field in the extension (v3)
- All members sign kind:445 events with this shared key
- Clients subscribe with `{ authors: [group_pubkey], kinds: [445] }` instead of `{ "#h": [nostr_group_id] }`
- Relays reject events with invalid signatures before delivery
- Non-members cannot produce valid signatures, so spam is blocked at the relay level

The key is **static across MLS epochs** (does not rotate on every Commit). It changes only when an admin explicitly rotates it, e.g. after removing a member. This avoids the complexity of epoch-derived keys (subscription churn, self-update DoS, competing commit message loss, welcome epoch lag).

Content encryption via `exporter_secret` and NIP-44 is **unchanged**. The signing key is used only for the outer Nostr event signature.

## Tradeoff: NIP-09 deletion

With a shared signing key, any group member can create a valid NIP-09 deletion request for another member's kind:445 event. This is a new capability that doesn't exist with ephemeral keys.

The threat is bounded (insider-only, observable but not attributable to a specific member, mitigated by client-side caching and multi-relay redundancy). The proposed defense:

- Clients MUST NOT honor NIP-09 deletion events that reference kind:445 events
- Clients MUST NOT issue NIP-09 or NIP-62 events using the `group_signing_key`
- Clients SHOULD monitor for unauthorized deletion/vanish events and alert users

The anti-spam benefit (cryptographic exclusion of all non-members) outweighs the NIP-09 risk (a bounded insider attack in an already-trusted group).

## Changes

| File | What changed |
|------|-------------|
| `01.md` (MIP-01) | New `group_signing_key` field, extension bumped to v3, key lifecycle section, NIP-09 defense, updated pseudocode |
| `03.md` (MIP-03) | Shared signing key replaces ephemeral keys, new subscription filter section, BIP340 requirement |
| `threat_model.md` | T.1.4 and T.10.2 updated with signing key countermeasure, new T.10.2.1 for NIP-09 deletion risk |

## Request for feedback

This is an RFC. Before implementation work begins, we'd like feedback on:

1. Is the tradeoff (spam prevention vs. NIP-09 deletion risk) acceptable?
2. Should key rotation after member removal be MUST or SHOULD?
3. Any concerns about storing a shared private key in the extension?
4. Is the migration path (dual-mode transition) worth specifying in the MIPs, or should it be left to implementations?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced group signing keys enabling shared cryptographic signatures for enhanced anti-spam protection and event verification.
  * Updated group event signing mechanism with stable group-based pubkeys for improved subscription filtering.

* **Documentation**
  * Updated extension format to version 3 supporting the new group signing key field.
  * Enhanced threat model documentation with signature-based filtering and key rotation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->