### PR TITLE
[codex] Specify thumbhash IMETA compatibility

### DIFF
--- a/04.md
+++ b/04.md
@@ -127,7 +127,7 @@ Content-addressed storage with encryption provides strong privacy guarantees:
 Media metadata is shared in chat messages through [NIP-92](https://github.com/nostr-protocol/nips/blob/master/92.md) compliant `imeta` tags within Group Messages:
 
 ```
-imeta url <blossom_url> m <mime_type> filename <filename> [dim <dimensions>] [blurhash <hash>] x <file_sha256> n <nonce_hex> v <version>
+imeta url <blossom_url> m <mime_type> filename <filename> [dim <dimensions>] [blurhash <hash>] [thumbhash <hash>] x <file_sha256> n <nonce_hex> v <version>
 ```
 
 ### Field Specifications
@@ -138,7 +138,8 @@ imeta url <blossom_url> m <mime_type> filename <filename> [dim <dimensions>] [bl
 | `m` | MIME type in canonical form as UTF-8 (e.g., "image/jpeg") | Yes |
 | `filename` | Original filename for display | Yes |
 | `dim` | Image/video dimensions as "widthxheight" | Optional |
-| `blurhash` | BlurHash for progressive loading | Optional |
+| `blurhash` | BlurHash preview hash | Optional |
+| `thumbhash` | ThumbHash preview hash | Optional |
 | `x` | SHA256 hash of original file content (hex-encoded) | Yes |
 | `n` | Encryption nonce (hex-encoded, 24 hex characters for 12 bytes) | Yes (v2+) |
 | `v` | Encryption version number (currently "mip04-v2", deprecated: "mip04-v1") | Yes |
@@ -146,6 +147,17 @@ imeta url <blossom_url> m <mime_type> filename <filename> [dim <dimensions>] [bl
 **Version-Specific Fields**:
 - **Version 2 (`mip04-v2`)**: The `n` field is **required** and contains a randomly generated 12-byte nonce, hex-encoded as 24 characters.
 - **Version 1 (`mip04-v1`)**: The `n` field is **not present** (nonce was derived deterministically). ⚠️ **Deprecated - MUST NOT be used for new media.**
+
+### Preview Hash Compatibility
+
+The `blurhash` and `thumbhash` fields are optional preview metadata for image media. They do not affect decryption or integrity verification.
+
+- Senders MAY include `blurhash`, `thumbhash`, or both.
+- New implementations SHOULD generate and emit `thumbhash`.
+- Senders MAY additionally emit `blurhash` for compatibility with clients that do not yet support `thumbhash`.
+- Receivers MUST parse both `blurhash` and `thumbhash` when present.
+- If both fields are present and supported, receivers SHOULD prefer `thumbhash` for preview rendering and fall back to `blurhash` if needed.
+- `blurhash` is retained in this version for backward compatibility only. Future versions of this specification are expected to remove `blurhash`.
 
 ### Integrity Verification
 
@@ -168,7 +180,7 @@ This ensures the decryption was successful and the file was not corrupted.
 4. **Generate random nonce** (12 bytes, cryptographically secure)
 5. **Encrypt** file with AEAD including metadata binding
 6. **Upload** encrypted blob to Blossom storage
-7. **Create `imeta`** tags with metadata, nonce (`n` field), and storage URL
+7. **Create `imeta`** tags with metadata, nonce (`n` field), storage URL, and optional preview hash fields (`thumbhash` RECOMMENDED for new implementations; `blurhash` OPTIONAL for compatibility)
 8. **Send** Group Message containing `imeta` tags
 
 **Receiving Media** (Version 2):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Changed
 
+- **Encrypted media previews**: [MIP-04](04.md) now documents optional `thumbhash` `imeta` tags alongside `blurhash`, recommends emitting `thumbhash` in new implementations, requires receivers to parse both preview hash fields, and notes that `blurhash` remains only for backward compatibility in this version. ([#64](https://github.com/marmot-protocol/marmot/pull/64))
+
 ### Added
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@
 
 ### Changed
 
-- **Encrypted media previews**: [MIP-04](04.md) now documents optional `thumbhash` `imeta` tags alongside `blurhash`, recommends emitting `thumbhash` in new implementations, requires receivers to parse both preview hash fields, and notes that `blurhash` remains only for backward compatibility in this version. ([#64](https://github.com/marmot-protocol/marmot/pull/64))
-
 ### Added
 
 ### Fixed
@@ -33,6 +31,8 @@
 - **KeyPackage migration**: `kind:30443` is now the canonical KeyPackage format. The Marmot rollout plan, including the May 1, 2026, at 00:00:00 UTC cutover guidance, is documented in [docs/migrations/2026-05-01-kind-30443-cutover.md](docs/migrations/2026-05-01-kind-30443-cutover.md).
 
 ### Changed
+
+- **Encrypted media previews**: [MIP-04](04.md) now documents optional `thumbhash` `imeta` tags alongside `blurhash`, recommends emitting `thumbhash` in new implementations, requires receivers to parse both preview hash fields, and notes that `blurhash` remains only for backward compatibility in this version. ([#64](https://github.com/marmot-protocol/marmot/pull/64))
 
 ### Added
 


### PR DESCRIPTION
## Summary

Updates MIP-04 so `thumbhash` is documented as an additional optional `imeta` field rather than a replacement for `blurhash`.

## What changed

- added optional `thumbhash <hash>` to the documented `imeta` format
- documented both `blurhash` and `thumbhash` in the field table
- added explicit compatibility guidance for senders and receivers
- specified that receivers should parse both fields and prefer `thumbhash` when both are present
- noted that `blurhash` is retained for backward compatibility in this version and is expected to be removed in a future version
- updated the send flow to mention the recommended `thumbhash` write path

## Why

This matches the compatibility direction discussed in MDK PR #195: support both preview hash formats without breaking existing `blurhash` content already in the wild.

## Validation

- `git diff --check`
- reviewed the repo for other `blurhash`/`thumbhash` references to keep the change scoped and consistent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated encrypted media preview spec to add a new preview hash option and clarify that previews may include one or both hashes.
  * New guidance: prefer the newer hash for rendering; fall back to the legacy hash for compatibility.
  * Sending flow updated to document optional preview hash fields and parsing/rendering expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->