### PR TITLE
feat(MIP-05): expand encrypted token size from 280 to 1084 bytes

### DIFF
--- a/05.md
+++ b/05.md
@@ -87,7 +87,7 @@ ciphertext = ChaCha20-Poly1305.encrypt(
 )
 
 // Token package includes ephemeral pubkey, nonce, and ciphertext
-encrypted_token = ephemeral_pubkey || nonce || ciphertext  // 32 + 12 + 236 = 280 bytes
+encrypted_token = ephemeral_pubkey || nonce || ciphertext  // 32 + 12 + 1040 = 1084 bytes
 ```
 
 **Probabilistic Property**: The combination of ephemeral keypairs and random nonces ensures that encrypting the same device token multiple times (for different groups) produces different ciphertexts with no linkage to the user's identity. This prevents the notification server from:
@@ -100,8 +100,8 @@ encrypted_token = ephemeral_pubkey || nonce || ciphertext  // 32 + 12 + 236 = 28
 To prevent group members from inferring other members' platforms (APNs vs FCM) from encrypted token size, all payloads are padded to a uniform size before encryption. Encrypted tokens use the following fixed-size wire formats:
 
 ```text
-TokenPlaintext = platform[1] || token_length[2] || device_token[token_length] || random_padding[220 - 3 - token_length]
-EncryptedToken = ephemeral_pubkey[32] || nonce[12] || ciphertext[236]
+TokenPlaintext = platform[1] || token_length[2] || device_token[token_length] || random_padding[1024 - 3 - token_length]
+EncryptedToken = ephemeral_pubkey[32] || nonce[12] || ciphertext[1040]
 ```
 
 **Field definitions**:
@@ -114,43 +114,42 @@ EncryptedToken = ephemeral_pubkey[32] || nonce[12] || ciphertext[236]
 - `random_padding`: Random bytes that fill the remaining plaintext space.
 
 **Size requirements**:
-- `TokenPlaintext` total size MUST be exactly 220 bytes.
-- `EncryptedToken` total size MUST be exactly 280 bytes.
+- `TokenPlaintext` total size MUST be exactly 1024 bytes.
+- `EncryptedToken` total size MUST be exactly 1084 bytes.
 
 **Validation requirements**:
-- If `platform` is `0x01` (APNs), `token_length` MUST be `32`.
-- If `platform` is `0x02` (FCM), `token_length` MUST be between `1` and `200`, inclusive.
-- No other `platform` values are valid.
+- `platform` MUST be `0x01` (APNs) or `0x02` (FCM). No other values are valid.
+- `token_length` MUST be between `1` and `1021`, inclusive.
 
-**Encryption produces uniform 280-byte tokens**:
-- Padded payload: 220 bytes
+**Encryption produces uniform 1084-byte tokens**:
+- Padded payload: 1024 bytes
 - ChaCha20-Poly1305 auth tag: 16 bytes
-- Ciphertext total: 236 bytes
-- Encrypted token: 32 (ephemeral pubkey) + 12 (nonce) + 236 (ciphertext) = **280 bytes**
+- Ciphertext total: 1040 bytes
+- Encrypted token: 32 (ephemeral pubkey) + 12 (nonce) + 1040 (ciphertext) = **1084 bytes**
 
 **Example - APNs token (32 bytes)**:
 ```
 platform       = 0x01
 token_length   = 0x00 0x20  (32 in big-endian)
 device_token   = <32 bytes>
-random_padding = <185 random bytes>
-Total: 1 + 2 + 32 + 185 = 220 bytes
+random_padding = <989 random bytes>
+Total: 1 + 2 + 32 + 989 = 1024 bytes
 ```
 
-**Example - FCM token (200 bytes)**:
+**Example - FCM token (250 bytes)**:
 ```
 platform       = 0x02
-token_length   = 0x00 0xC8  (200 in big-endian)
-device_token   = <200 bytes>
-random_padding = <17 random bytes>
-Total: 1 + 2 + 200 + 17 = 220 bytes
+token_length   = 0x00 0xFA  (250 in big-endian)
+device_token   = <250 bytes>
+random_padding = <771 random bytes>
+Total: 1 + 2 + 250 + 771 = 1024 bytes
 ```
 
 **Server Decryption**: The server decrypts by:
 1. Extracting the first 32 bytes as the ephemeral public key
 2. Extracting the next 12 bytes as the nonce
 3. Using the ephemeral public key and its private key to derive the same encryption key via ECDH + HKDF
-4. Decrypting the remaining 236 bytes as the ciphertext (produces a 220-byte `TokenPlaintext`)
+4. Decrypting the remaining 1040 bytes as the ciphertext (produces a 1024-byte `TokenPlaintext`)
 5. Parsing the `TokenPlaintext`:
    - Read platform (1 byte): 0x01 = APNs, 0x02 = FCM
    - Read token_length (2 bytes, big-endian)
@@ -210,7 +209,7 @@ When a device joins a group or needs to refresh its view of active tokens, it se
 
 **Tags**:
 - **token**: One or more `token` tags, each containing:
-  - First value: Complete 280-byte `EncryptedToken` as RFC 4648 standard base64 with padding
+  - First value: Complete 1084-byte `EncryptedToken` as RFC 4648 standard base64 with padding
   - Second value: The notification server's public key used for encryption as 32-byte x-only Nostr public key hex. This is required for interoperability between different clients.
   - Third value: A relay hint URL where the notification server's `kind: 10050` event can be found. This helps senders discover the server's inbox relays even if they don't share relays with the server.
 
@@ -240,7 +239,7 @@ Any group member may respond with their complete view of all tokens as an unsign
 
 **Tags**:
 - **token**: One or more `token` tags, each containing:
-  - First value: Complete 280-byte `EncryptedToken` as RFC 4648 standard base64 with padding
+  - First value: Complete 1084-byte `EncryptedToken` as RFC 4648 standard base64 with padding
   - Second value: The notification server's public key as 32-byte x-only Nostr public key hex
   - Third value: A relay hint URL where the notification server's `kind: 10050` event can be found
   - Fourth value: MLS leaf index (decimal string) of the device that owns this token
@@ -423,7 +422,7 @@ The notification trigger uses [NIP-59 Gift Wrap](https://github.com/nostr-protoc
 ```
 
 **Notes**:
-- The `content` field of the rumor MUST be a single RFC 4648 standard base64 string with padding containing the concatenation of one or more `EncryptedToken` values (each token is exactly 280 bytes). `kind: 446` MUST NOT encode tokens as a JSON array or any other structure.
+- The `content` field of the rumor MUST be a single RFC 4648 standard base64 string with padding containing the concatenation of one or more `EncryptedToken` values (each token is exactly 1084 bytes). `kind: 446` MUST NOT encode tokens as a JSON array or any other structure.
 - The rumor MUST include `["v", "mip05-v1"]` and `["encoding", "base64"]`. Implementations MUST reject missing or unrecognized values.
 - The rumor's `pubkey` MUST be a freshly generated random ephemeral key (not the sender's identity), encoded as a 32-byte x-only Nostr public key, to prevent the server from linking notification events to users
 - The seal MUST be signed by the SAME ephemeral key used in the rumor's `pubkey` field, providing authentication without revealing the real sender's identity
@@ -432,10 +431,10 @@ The notification trigger uses [NIP-59 Gift Wrap](https://github.com/nostr-protoc
 
 **Size Constraints**: The kind 446 event content is limited by the NIP-59 gift wrap process and relay event size limits (commonly 64-128KB depending on relay implementation):
 
-- **Uniform encrypted token size**: 280 bytes — see Payload Padding section
+- **Uniform encrypted token size**: 1084 bytes — see Payload Padding section
 - **Content encoding**: All tokens concatenated, then base64-encoded as a single blob
-- **Practical capacity** (assuming 64KB limit, ~60KB usable after event overhead): ~160 tokens per event
-- **Recommendation**: Batch at 100 tokens per event to stay well under limits across all relay implementations. For groups with more than 100 members, clients MUST send multiple `kind: 446` events.
+- **Practical capacity** (assuming 64KB limit, ~60KB usable after event overhead): ~41 tokens per event
+- **Recommendation**: Batch at 25 tokens per event to stay well under limits across all relay implementations. For groups with more than 25 members, clients MUST send multiple `kind: 446` events.
 
 ### Validation Rules
 
@@ -444,16 +443,16 @@ When processing a `kind: 446` rumor, servers MUST apply the following validation
 1. Reject the rumor if the `v` tag is missing or not `mip05-v1`.
 2. Reject the rumor if the `encoding` tag is missing or not `base64`.
 3. Reject the rumor if `content` fails RFC 4648 standard base64 decoding.
-4. Reject the rumor if the decoded byte length is not a multiple of 280.
-5. Split the decoded bytes into 280-byte `EncryptedToken` chunks.
+4. Reject the rumor if the decoded byte length is not a multiple of 1084.
+5. Split the decoded bytes into 1084-byte `EncryptedToken` chunks.
 6. For each chunk, ignore that token if the 32-byte ephemeral public key is invalid, ECDH/HKDF key derivation fails, or ChaCha20-Poly1305 authentication fails.
-7. After successful decryption, ignore that token if `platform` is not `0x01` or `0x02`, or if `token_length` is invalid for that platform.
+7. After successful decryption, ignore that token if `platform` is not `0x01` or `0x02`, or if `token_length` is not between `1` and `1021` inclusive.
 
 ### Processing Flow
 
 When a device sends a message to a group:
 
-1. **Collect tokens**: Get all stored encrypted tokens from all active leaves in the group (all tokens are already uniform 280 bytes due to payload padding during encryption)
+1. **Collect tokens**: Get all stored encrypted tokens from all active leaves in the group (all tokens are already uniform 1084 bytes due to payload padding during encryption)
 2. **Filter active leaves**: Only include tokens from leaves that still exist in the MLS tree (removes tokens from departed members)
 3. **Handling multiple notification servers**: It's possible that the tokens will be from multiple different notification servers (from different clients). If so, do the following steps for each server. Note: this reveals which notification servers (and thus which clients) group members use—a known metadata tradeoff for interoperability.
 4. **Add decoys**: Include real encrypted tokens as decoys to obscure group size (random bytes don't work—real tokens have valid curve points and pass AEAD authentication, so servers trivially distinguish random bytes):
@@ -467,8 +466,8 @@ When a device sends a message to a group:
 9. **Server processes**:
    - Unwraps the gift wrap using its private key per NIP-59
    - Decrypts and verifies the inner seal
-   - Extracts and validates the kind 446 rumor (verifies the rumor's pubkey matches the seal's pubkey, validates `v` and `encoding`, rejects invalid base64, rejects decoded lengths that are not multiples of 280)
-   - Splits the decoded bytes into 280-byte chunks
+   - Extracts and validates the kind 446 rumor (verifies the rumor's pubkey matches the seal's pubkey, validates `v` and `encoding`, rejects invalid base64, rejects decoded lengths that are not multiples of 1084)
+   - Splits the decoded bytes into 1084-byte chunks
    - For each chunk: extracts ephemeral pubkey, derives encryption key via ECDH + HKDF, decrypts ciphertext, and ignores the chunk on ECDH failure, AEAD authentication failure, invalid `platform`, or invalid `token_length`
    - Sends push notifications to APNs/FCM for valid tokens (silently ignores decoys/invalid tokens)
 
@@ -546,8 +545,8 @@ Clients MUST:
 - Use **native platform tokens**: APNs tokens on iOS, FCM tokens on Android via Firebase SDK
 - Use the **hardcoded notification server public key** for token encryption
 - Fetch the server's **inbox relays** from the server's latest valid `kind: 10050` event by reading its `relay` tags
-- Implement **probabilistic token encryption** per the Encryption Format and Payload Padding sections: generate ephemeral secp256k1 keypair per token, use 32-byte x-only public keys, derive encryption key via ECDH + HKDF (Extract then Expand with info `"mip05-token-encryption"`), construct 220-byte padded payload, encrypt with ChaCha20-Poly1305 using random 12-byte nonce
-- Use **padded payload format**: platform (0x01=APNs, 0x02=FCM) || token_length (2 bytes BE) || device_token || random_padding (to 220 bytes total)
+- Implement **probabilistic token encryption** per the Encryption Format and Payload Padding sections: generate ephemeral secp256k1 keypair per token, use 32-byte x-only public keys, derive encryption key via ECDH + HKDF (Extract then Expand with info `"mip05-token-encryption"`), construct 1024-byte padded payload, encrypt with ChaCha20-Poly1305 using random 12-byte nonce
+- Use **padded payload format**: platform (0x01=APNs, 0x02=FCM) || token_length (2 bytes BE) || device_token || random_padding (to 1024 bytes total)
 - Implement handlers for **token distribution events** (447, 448, 449) as the payload of MLS Application Messages (kind: 445)
 - Ensure all token distribution events (447, 448, 449) remain **unsigned** (no `sig` field) per MIP-03 requirements
 - Verify sender's **MLS identity** when processing token events
@@ -581,9 +580,9 @@ Servers MUST:
 - Monitor inbox relays for `kind: 1059` gift-wrapped events addressed to the server's pubkey
 - **Unwrap gift-wrapped events** per NIP-59: decrypt the outer layer to extract the `kind: 13` seal, then decrypt the seal to extract the `kind: 446` rumor
 - **Verify seal authenticity**: ensure the seal is properly signed and the rumor's pubkey matches the seal's pubkey
-- Reject `kind: 446` rumors with missing or unrecognized `v` / `encoding` tags, invalid base64 content, or decoded lengths that are not multiples of 280
-- **Decrypt tokens** by: extracting ephemeral pubkey (first 32 bytes), nonce (next 12 bytes), and ciphertext (236 bytes); deriving encryption key via ECDH + HKDF (Extract then Expand with info `"mip05-token-encryption"`); decrypting with ChaCha20-Poly1305
-- **Parse padded payload** (220 bytes): read platform (0x01=APNs, 0x02=FCM), read token_length (2 bytes BE), read device_token, discard padding
+- Reject `kind: 446` rumors with missing or unrecognized `v` / `encoding` tags, invalid base64 content, or decoded lengths that are not multiples of 1084
+- **Decrypt tokens** by: extracting ephemeral pubkey (first 32 bytes), nonce (next 12 bytes), and ciphertext (1040 bytes); deriving encryption key via ECDH + HKDF (Extract then Expand with info `"mip05-token-encryption"`); decrypting with ChaCha20-Poly1305
+- **Parse padded payload** (1024 bytes): read platform (0x01=APNs, 0x02=FCM), read token_length (2 bytes BE), read device_token, discard padding
 - Verify gift wrap and inner event structure before processing
 - Maintain **direct integrations** with both APNs and FCM (no intermediary services)
 - Route tokens to **appropriate push service** based on platform identifier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 - **Encoding format**: KeyPackage (kind:443) and Welcome (kind:444) events now require base64 encoding for the `content` field. The `encoding` tag MUST be `["encoding", "base64"]`. Hex encoding was used by early implementations but is no longer supported. Implementations MUST reject events with missing or non-base64 `encoding` tags.
 - **KeyPackage migration**: `kind:30443` is now the canonical KeyPackage format. The Marmot rollout plan, including the May 1, 2026, at 00:00:00 UTC cutover guidance, is documented in [docs/migrations/2026-05-01-kind-30443-cutover.md](docs/migrations/2026-05-01-kind-30443-cutover.md).
+- **MIP-05 token size**: `EncryptedToken` expanded from 280 to 1084 bytes (`TokenPlaintext` from 220 to 1024 bytes) to accommodate larger FCM tokens and future UnifiedPush support. Platform-specific `token_length` validation replaced with a universal range of 1–1021. Batch recommendation lowered from 100 to 25 tokens per `kind:446` event.
 
 ### Changed
 


### PR DESCRIPTION
## Summary

Expands the encrypted token size specification in MIP-05 from 280 bytes to 1084 bytes to accommodate larger device tokens and improve padding uniformity.

## Changes

- **Token size**: Updated `EncryptedToken` from 280 to 1084 bytes
  - Ephemeral pubkey: 32 bytes
  - Nonce: 12 bytes
  - Ciphertext: 1040 bytes (increased from 236)

- **Plaintext payload**: Updated `TokenPlaintext` from 220 to 1024 bytes
  - Platform: 1 byte
  - Token length: 2 bytes
  - Device token: up to 1021 bytes
  - Random padding: fills remaining space

- **Validation**: Updated token_length constraints to 1-1021 bytes (from platform-specific 1-200 for FCM, 32 for APNs)

- **Batching recommendations**: Reduced from 100 tokens per event to 25 tokens per event (due to larger token size)

- **Updated all examples and documentation** to reflect new size constraints throughout the specification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated encrypted token wire format: fixed-size plaintext/padding increased to 1024 bytes and encrypted token size adjusted accordingly.
  * Revised token validation to a single global allowed length range (1–1021) and restricted platform identifiers.
  * Changed processing rules from 280‑byte to 1084‑byte chunks and tightened server rejection/validation behavior.
  * Lowered recommended batching for kind:446 events and refreshed examples to match new sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->