### PR TITLE
feat(MIP-01, MIP-03): add disappearing messages, bump extension to v3

### DIFF
--- a/01.md
+++ b/01.md
@@ -64,6 +64,7 @@ The Marmot Group Data Extension serves several critical functions:
 3. **Access Control**: Establishes cryptographically verified admin roles independent of MLS protocol roles
 4. **Group Image Encryption**: Enables secure, encrypted sharing of the group image with ChaCha20-Poly1305 and optional cleanup of old images via deterministic upload identity derivation
 5. **Metadata Protection**: Ensures group metadata changes are authenticated and verifiable by all members
+6. **Disappearing Messages**: Configures per-group message expiration so that clients can automatically delete messages after a specified duration and relay-side expiration can be hinted via [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md)
 
 ### TLS Serialization Requirements
 
@@ -83,7 +84,7 @@ Incorrect TLS serialization will cause interoperability failures.
 
 | Field              | TLS Type                          | Length Constraints | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | ------------------ | --------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `version`          | `uint16 version`                  | Exactly 2 bytes    | Extension format version number. Current version is `2`. Implementations MUST validate version compatibility before processing extension data.                                                                                                                                                                                                                                                                                                                                      |
+| `version`          | `uint16 version`                  | Exactly 2 bytes    | Extension format version number. Current version is `3`. Implementations MUST validate version compatibility before processing extension data.                                                                                                                                                                                                                                                                      |
 | `nostr_group_id`   | `opaque nostr_group_id[32]`       | Exactly 32 bytes   | A 32-byte identifier for the group used in Nostr protocol operations. This value is distinct from the MLS group ID and MAY be updated over time through group proposals. This identifier is used in the `h` tags when publishing group message events to Nostr relays. MUST be cryptographically random when initially generated.                                                                                                                                                   |
 | `name`             | `opaque name<0..2^16-1>`          | 0-65535 bytes      | UTF-8 encoded group name. MUST be valid UTF-8. SHOULD be limited to 255 characters for practical display purposes. Empty string is permitted for unnamed groups.                                                                                                                                                                                                                                                                                                                    |
 | `description`      | `opaque description<0..2^16-1>`   | 0-65535 bytes      | UTF-8 encoded group description. MUST be valid UTF-8. SHOULD be limited to 1000 characters for practical display purposes. Empty string is permitted.                                                                                                                                                                                                                                                                                                                               |
@@ -93,6 +94,7 @@ Incorrect TLS serialization will cause interoperability failures.
 | `image_key`        | `opaque image_key<0..32>`         | 0 or 32 bytes      | Image encryption seed. Used with HKDF to derive the ChaCha20-Poly1305 encryption key (see [Image Encryption](#image-encryption)). MUST be cryptographically random when generated. Empty when no image is set; exactly 32 bytes when set.                                                                                                                                                                                                                                           |
 | `image_nonce`      | `opaque image_nonce<0..12>`       | 0 or 12 bytes      | ChaCha20-Poly1305 nonce for group image encryption. MUST be cryptographically random and unique for each image. Used with the derived encryption key for authenticated encryption/decryption. Empty when no image is set; exactly 12 bytes when set.                                                                                                                                                                                                                                |
 | `image_upload_key` | `opaque image_upload_key<0..32>`  | 0 or 32 bytes      | Upload seed for deriving the Nostr keypair used for Blossom upload authentication (see [Image Upload Identity](#image-upload-identity)). Cryptographically independent from `image_key`. MUST be cryptographically random when generated. Empty when no image is set; exactly 32 bytes when set.                                                                                                                                                                                    |
+| `disappearing_message_duration_secs` | `opaque disappearing_message_duration_secs<0..8>` | 0 or 8 bytes | Disappearing message duration in seconds. Empty (zero-length) when disabled (`None` — messages persist forever); exactly 8 bytes (big-endian `uint64`) when enabled (`Some(n)` — messages expire `n` seconds after creation). A value of `0` MUST be rejected as invalid. Added in version 3. |
 
 #### TLS Structure Definition
 
@@ -102,7 +104,7 @@ In TLS presentation language, the extension data MUST be structured as:
 opaque RelayUrl<0..2^16-1>;        // UTF-8 encoded WebSocket URL
 
 struct {
-    uint16 version;                    // Version number (current: 2)
+    uint16 version;                    // Version number (current: 3)
     opaque nostr_group_id[32];
     opaque name<0..2^16-1>;
     opaque description<0..2^16-1>;
@@ -112,6 +114,7 @@ struct {
     opaque image_key<0..32>;           // 0 or 32 bytes (encryption seed)
     opaque image_nonce<0..12>;         // 0 or 12 bytes
     opaque image_upload_key<0..32>;    // 0 or 32 bytes (upload seed)
+    opaque disappearing_message_duration_secs<0..8>;  // 0 or 8 bytes (v3+)
 } NostrGroupData;
 ```
 
@@ -120,7 +123,8 @@ struct {
 The `version` field enables forward-compatible evolution of the extension format:
 
 - **Version `1`**: Initial versioned format (deprecated). Used `image_key` directly as the ChaCha20-Poly1305 encryption key and derived the upload keypair from `image_key`. Did not include `image_upload_key` field. Used hex-encoded admin pubkeys.
-- **Version `2`** (current): Uses raw 32-byte admin pubkeys. Uses `image_key` as a seed for HKDF derivation of the encryption key. Adds `image_upload_key` as a separate seed for upload keypair derivation, providing cryptographic independence between encryption and upload authentication. Variable-length image fields allow empty encoding when no image is set.
+- **Version `2`**: Uses raw 32-byte admin pubkeys. Uses `image_key` as a seed for HKDF derivation of the encryption key. Adds `image_upload_key` as a separate seed for upload keypair derivation, providing cryptographic independence between encryption and upload authentication. Variable-length image fields allow empty encoding when no image is set.
+- **Version `3`** (current): Adds `disappearing_message_duration_secs` field for per-group message expiration. `None` (empty encoding) means messages persist forever; `Some(n)` (8-byte big-endian uint64) means messages expire `n` seconds after creation. A duration of `0` MUST be rejected as invalid. Existing v1/v2 groups are forward-compatible — the field deserializes as `None` (disabled).
 - **Version `0`**: Reserved and MUST be rejected as invalid. Version numbering starts at 1.
 - **Future Versions**: Higher version numbers indicate newer formats with additional fields appended at the end
 - **Forward Compatibility**: Implementations SHOULD gracefully handle unknown versions by parsing known fields and ignoring unknown trailing fields
@@ -210,6 +214,31 @@ When an admin updates the group image:
 - **Key independence**: `image_key` and `image_upload_key` are independently random, so compromise of one does not affect the other
 - **Forward compatibility**: Old members who leave cannot access new group images (they don't receive updated extension data)
 
+#### Disappearing Messages
+
+The `disappearing_message_duration_secs` field (v3+) configures per-group message expiration:
+
+- **`None`** (empty encoding): Messages persist forever. This is the default.
+- **`Some(n)`** (8-byte big-endian uint64): Messages expire `n` seconds after creation. `n` MUST be greater than 0.
+
+**Validation**: A duration of `0` MUST be rejected at both group creation and group data update. Implementations MUST return a clear error when `0` is provided.
+
+**Update semantics**: The field supports a tri-state update model:
+- Omit from update: Leave the current value unchanged
+- Set to `Some(n)`: Enable or change the duration (n > 0)
+- Set to `None`: Disable disappearing messages
+
+**NIP-40 expiration tags**: When a group has `disappearing_message_duration_secs` set, implementations MUST auto-apply a [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) `expiration` tag to the outer `kind: 445` wrapper event. The expiration timestamp MUST be computed as `rumor.created_at + duration_secs`. Any caller-supplied expiration tag MUST be replaced by the auto-computed one to prevent conflicting expiration values. See [MIP-03](03.md) for the complete Group Event structure.
+
+**Local deletion**: Implementations SHOULD provide APIs for clients to delete expired messages from local storage. Deletion of messages from local storage is a local-only operation and does not publish any Nostr events. Implementations SHOULD also consider:
+- Per-message deletion by event ID
+- Bulk deletion of messages older than a given timestamp
+- Deletion of processed message tracking records when no longer needed
+
+**Backward compatibility**: v1/v2 groups do not include this field. When deserializing a v1/v2 extension, the field MUST default to `None` (messages persist forever).
+
+**Security considerations**: Disappearing messages provide a best-effort privacy enhancement. They do NOT guarantee message deletion from all recipients' devices — group members may retain copies. The NIP-40 expiration tag hints to relays that events can be discarded after expiry, but relay compliance is not guaranteed. See [threat_model.md](threat_model.md) for a full analysis.
+
 #### Extension Lifecycle Management
 
 **Creation**: When creating a new group, this extension MUST be populated with initial values and included in the group's required capabilities.
@@ -226,7 +255,7 @@ When an admin updates the group image:
 **Version Detection**: Implementations MUST validate the extension format version:
 
 ```pseudocode
-MAX_SUPPORTED_VERSION = 2
+MAX_SUPPORTED_VERSION = 3
 
 function detect_version(extension_data) {
     if (extension_data.length < 2) {
@@ -263,8 +292,9 @@ function validate_structure(data, version) {
     // Minimum size with all variable fields empty (1-byte QUIC varint prefix each):
     //   version(2) + nostr_group_id(32) + name(1+0) + description(1+0) +
     //   admin_pubkeys(1+0) + relays(1+0) + image_hash(1+0) + image_key(1+0) +
-    //   image_nonce(1+0) + image_upload_key(1+0)
-    MIN_SIZE = 2 + 32 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1  // = 42 bytes
+    //   image_nonce(1+0) + image_upload_key(1+0) +
+    //   disappearing_message_duration_secs(1+0)
+    MIN_SIZE = 2 + 32 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1  // = 43 bytes
 
     if (data.length < MIN_SIZE) return false
 
@@ -273,7 +303,8 @@ function validate_structure(data, version) {
     // Validate each variable-length field in order
     variable_fields = [
         "name", "description", "admin_pubkeys", "relays",
-        "image_hash", "image_key", "image_nonce", "image_upload_key"
+        "image_hash", "image_key", "image_nonce", "image_upload_key",
+        "disappearing_message_duration_secs"
     ]
 
     for field in variable_fields {
@@ -289,7 +320,7 @@ function validate_structure(data, version) {
 
 **Forward Compatibility**: The extension format is append-only: future versions may only add new fields at the end. Parsers MUST parse fields in the documented order. When encountering unknown future versions:
 
-- Parse known fields in order (version, nostr_group_id, name, description, admin_pubkeys, relays, image_hash, image_key, image_nonce, image_upload_key)
+- Parse known fields in order (version, nostr_group_id, name, description, admin_pubkeys, relays, image_hash, image_key, image_nonce, image_upload_key, disappearing_message_duration_secs)
 - Ignore any unknown trailing fields beyond the last known field
 - Continue normal operation with available data
 - Log warning about unknown version for debugging
@@ -309,8 +340,9 @@ function validate_structure(data, version) {
 
 **Version-Specific Implementation**:
 
-- **New Groups**: MUST create with version `2` format
+- **New Groups**: MUST create with version `3` format
 - **Version 1 Support**: Implementations SHOULD support reading version 1 extensions for backward compatibility. In version 1, `image_key` is used directly as the encryption key (not as an HKDF seed), `image_upload_key` is absent (the upload keypair is derived from `image_key` using context `"mip01-blossom-upload-v1"`), and admin pubkeys are hex-encoded strings
+- **Version 2 Support**: Implementations SHOULD support reading version 2 extensions for backward compatibility. Version 2 groups do not include the `disappearing_message_duration_secs` field; it SHOULD be treated as `None` (disabled)
 - **Future Versions**: SHOULD implement forward compatibility for unknown versions
 - **Error Handling**: MUST gracefully handle version mismatches with clear error messages
 
@@ -344,3 +376,4 @@ This MIP defines the foundation for creating secure, Nostr-integrated groups:
 - Private MLS group IDs (never publish to relays)
 - ChaCha20-Poly1305 encryption for group images with HKDF key derivation: `HKDF-Extract(salt=None, IKM=image_key)` then `HKDF-Expand(prk, "mip01-image-encryption-v2", 32)`
 - Deterministic upload keypair derivation using `HKDF-Extract(salt=None, IKM=image_upload_key)` then `HKDF-Expand(prk, "mip01-blossom-upload-v2", 32)` for Blossom authentication and cleanup
+- Disappearing message duration validation: reject `0`, propagate through group creation/update/welcome flows, auto-apply NIP-40 expiration tag on kind: 445 events when enabled

--- a/01.md
+++ b/01.md
@@ -94,7 +94,7 @@ Incorrect TLS serialization will cause interoperability failures.
 | `image_key`        | `opaque image_key<0..32>`         | 0 or 32 bytes      | Image encryption seed. Used with HKDF to derive the ChaCha20-Poly1305 encryption key (see [Image Encryption](#image-encryption)). MUST be cryptographically random when generated. Empty when no image is set; exactly 32 bytes when set.                                                                                                                                                                                                                                           |
 | `image_nonce`      | `opaque image_nonce<0..12>`       | 0 or 12 bytes      | ChaCha20-Poly1305 nonce for group image encryption. MUST be cryptographically random and unique for each image. Used with the derived encryption key for authenticated encryption/decryption. Empty when no image is set; exactly 12 bytes when set.                                                                                                                                                                                                                                |
 | `image_upload_key` | `opaque image_upload_key<0..32>`  | 0 or 32 bytes      | Upload seed for deriving the Nostr keypair used for Blossom upload authentication (see [Image Upload Identity](#image-upload-identity)). Cryptographically independent from `image_key`. MUST be cryptographically random when generated. Empty when no image is set; exactly 32 bytes when set.                                                                                                                                                                                    |
-| `disappearing_message_duration_secs` | `opaque disappearing_message_duration_secs<0..8>` | 0 or 8 bytes | Disappearing message duration in seconds. Empty (zero-length) when disabled (`None` — messages persist forever); exactly 8 bytes (big-endian `uint64`) when enabled (`Some(n)` — messages expire `n` seconds after creation). A value of `0` MUST be rejected as invalid. Added in version 3. |
+| `disappearing_message_secs` | `opaque disappearing_message_secs<0..8>` | 0 or 8 bytes | Disappearing message duration in seconds. Empty (zero-length) when disabled (`None` — messages persist forever); exactly 8 bytes (big-endian `uint64`) when enabled (`Some(n)` — messages expire `n` seconds after creation). A value of `0` MUST be rejected as invalid. Added in version 3. |
 
 #### TLS Structure Definition
 
@@ -114,7 +114,7 @@ struct {
     opaque image_key<0..32>;           // 0 or 32 bytes (encryption seed)
     opaque image_nonce<0..12>;         // 0 or 12 bytes
     opaque image_upload_key<0..32>;    // 0 or 32 bytes (upload seed)
-    opaque disappearing_message_duration_secs<0..8>;  // 0 or 8 bytes (v3+)
+    opaque disappearing_message_secs<0..8>;  // 0 or 8 bytes (v3+)
 } NostrGroupData;
 ```
 
@@ -124,10 +124,11 @@ The `version` field enables forward-compatible evolution of the extension format
 
 - **Version `1`**: Initial versioned format (deprecated). Used `image_key` directly as the ChaCha20-Poly1305 encryption key and derived the upload keypair from `image_key`. Did not include `image_upload_key` field. Used hex-encoded admin pubkeys.
 - **Version `2`**: Uses raw 32-byte admin pubkeys. Uses `image_key` as a seed for HKDF derivation of the encryption key. Adds `image_upload_key` as a separate seed for upload keypair derivation, providing cryptographic independence between encryption and upload authentication. Variable-length image fields allow empty encoding when no image is set.
-- **Version `3`** (current): Adds `disappearing_message_duration_secs` field for per-group message expiration. `None` (empty encoding) means messages persist forever; `Some(n)` (8-byte big-endian uint64) means messages expire `n` seconds after creation. A duration of `0` MUST be rejected as invalid. Existing v1/v2 groups are forward-compatible — the field deserializes as `None` (disabled).
+- **Version `3`** (current): Adds `disappearing_message_secs` field for per-group message expiration. `None` (empty encoding) means messages persist forever; `Some(n)` (8-byte big-endian uint64) means messages expire `n` seconds after creation. A duration of `0` MUST be rejected as invalid.
 - **Version `0`**: Reserved and MUST be rejected as invalid. Version numbering starts at 1.
 - **Future Versions**: Higher version numbers indicate newer formats with additional fields appended at the end
 - **Forward Compatibility**: Implementations SHOULD gracefully handle unknown versions by parsing known fields and ignoring unknown trailing fields
+- **Default Values for Older Versions**: The extension format is append-only. When a newer implementation parses an older version that lacks fields introduced in a later version, those missing fields MUST default to their "absent" value — empty for variable-length opaque fields, `None` for optional fields. This is a general rule for the extension and applies to every appended field, not just the most recently added one.
 
 ### Implementation Considerations
 
@@ -216,7 +217,7 @@ When an admin updates the group image:
 
 #### Disappearing Messages
 
-The `disappearing_message_duration_secs` field (v3+) configures per-group message expiration:
+The `disappearing_message_secs` field (v3+) configures per-group message expiration:
 
 - **`None`** (empty encoding): Messages persist forever. This is the default.
 - **`Some(n)`** (8-byte big-endian uint64): Messages expire `n` seconds after creation. `n` MUST be greater than 0.
@@ -228,14 +229,12 @@ The `disappearing_message_duration_secs` field (v3+) configures per-group messag
 - Set to `Some(n)`: Enable or change the duration (n > 0)
 - Set to `None`: Disable disappearing messages
 
-**NIP-40 expiration tags**: When a group has `disappearing_message_duration_secs` set, implementations MUST auto-apply a [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) `expiration` tag to the outer `kind: 445` wrapper event. The expiration timestamp MUST be computed as `rumor.created_at + duration_secs`. Any caller-supplied expiration tag MUST be replaced by the auto-computed one to prevent conflicting expiration values. See [MIP-03](03.md) for the complete Group Event structure.
+**NIP-40 expiration tags**: When a group has `disappearing_message_secs` set, implementations MUST auto-apply a [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) `expiration` tag to the outer `kind: 445` wrapper event. The expiration timestamp MUST be computed as `rumor.created_at + disappearing_message_secs`. Any caller-supplied expiration tag MUST be replaced by the auto-computed one to prevent conflicting expiration values. See [MIP-03](03.md) for the complete Group Event structure.
 
 **Local deletion**: Implementations SHOULD provide APIs for clients to delete expired messages from local storage. Deletion of messages from local storage is a local-only operation and does not publish any Nostr events. Implementations SHOULD also consider:
 - Per-message deletion by event ID
 - Bulk deletion of messages older than a given timestamp
 - Deletion of processed message tracking records when no longer needed
-
-**Backward compatibility**: v1/v2 groups do not include this field. When deserializing a v1/v2 extension, the field MUST default to `None` (messages persist forever).
 
 **Security considerations**: Disappearing messages provide a best-effort privacy enhancement. They do NOT guarantee message deletion from all recipients' devices — group members may retain copies. The NIP-40 expiration tag hints to relays that events can be discarded after expiry, but relay compliance is not guaranteed. See [threat_model.md](threat_model.md) for a full analysis.
 
@@ -293,7 +292,7 @@ function validate_structure(data, version) {
     //   version(2) + nostr_group_id(32) + name(1+0) + description(1+0) +
     //   admin_pubkeys(1+0) + relays(1+0) + image_hash(1+0) + image_key(1+0) +
     //   image_nonce(1+0) + image_upload_key(1+0) +
-    //   disappearing_message_duration_secs(1+0)
+    //   disappearing_message_secs(1+0)
     MIN_SIZE = 2 + 32 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1  // = 43 bytes
 
     if (data.length < MIN_SIZE) return false
@@ -304,7 +303,7 @@ function validate_structure(data, version) {
     variable_fields = [
         "name", "description", "admin_pubkeys", "relays",
         "image_hash", "image_key", "image_nonce", "image_upload_key",
-        "disappearing_message_duration_secs"
+        "disappearing_message_secs"
     ]
 
     for field in variable_fields {
@@ -320,7 +319,7 @@ function validate_structure(data, version) {
 
 **Forward Compatibility**: The extension format is append-only: future versions may only add new fields at the end. Parsers MUST parse fields in the documented order. When encountering unknown future versions:
 
-- Parse known fields in order (version, nostr_group_id, name, description, admin_pubkeys, relays, image_hash, image_key, image_nonce, image_upload_key, disappearing_message_duration_secs)
+- Parse known fields in order (version, nostr_group_id, name, description, admin_pubkeys, relays, image_hash, image_key, image_nonce, image_upload_key, disappearing_message_secs)
 - Ignore any unknown trailing fields beyond the last known field
 - Continue normal operation with available data
 - Log warning about unknown version for debugging
@@ -342,7 +341,7 @@ function validate_structure(data, version) {
 
 - **New Groups**: MUST create with version `3` format
 - **Version 1 Support**: Implementations SHOULD support reading version 1 extensions for backward compatibility. In version 1, `image_key` is used directly as the encryption key (not as an HKDF seed), `image_upload_key` is absent (the upload keypair is derived from `image_key` using context `"mip01-blossom-upload-v1"`), and admin pubkeys are hex-encoded strings
-- **Version 2 Support**: Implementations SHOULD support reading version 2 extensions for backward compatibility. Version 2 groups do not include the `disappearing_message_duration_secs` field; it SHOULD be treated as `None` (disabled)
+- **Version 2 Support**: Implementations SHOULD support reading version 2 extensions for backward compatibility. Per the general append-only rule (see [Version Field](#version-field)), any v3+ fields absent from a v2 extension default to their absent value (e.g., `disappearing_message_secs` defaults to `None`)
 - **Future Versions**: SHOULD implement forward compatibility for unknown versions
 - **Error Handling**: MUST gracefully handle version mismatches with clear error messages
 
@@ -376,4 +375,4 @@ This MIP defines the foundation for creating secure, Nostr-integrated groups:
 - Private MLS group IDs (never publish to relays)
 - ChaCha20-Poly1305 encryption for group images with HKDF key derivation: `HKDF-Extract(salt=None, IKM=image_key)` then `HKDF-Expand(prk, "mip01-image-encryption-v2", 32)`
 - Deterministic upload keypair derivation using `HKDF-Extract(salt=None, IKM=image_upload_key)` then `HKDF-Expand(prk, "mip01-blossom-upload-v2", 32)` for Blossom authentication and cleanup
-- Disappearing message duration validation: reject `0`, propagate through group creation/update/welcome flows, auto-apply NIP-40 expiration tag on kind: 445 events when enabled
+- `disappearing_message_secs` validation: reject `0`, propagate through group creation/update/welcome flows, auto-apply NIP-40 expiration tag on kind: 445 events when enabled

--- a/01.md
+++ b/01.md
@@ -217,17 +217,14 @@ When an admin updates the group image:
 
 #### Disappearing Messages
 
-The `disappearing_message_secs` field (v3+) configures per-group message expiration:
+The `disappearing_message_secs` field (v3+) configures per-group message expiration. It has exactly two on-wire representations:
 
 - **`None`** (empty encoding): Messages persist forever. This is the default.
 - **`Some(n)`** (8-byte big-endian uint64): Messages expire `n` seconds after creation. `n` MUST be greater than 0.
 
 **Validation**: A duration of `0` MUST be rejected at both group creation and group data update. Implementations MUST return a clear error when `0` is provided.
 
-**Update semantics**: The field supports a tri-state update model:
-- Omit from update: Leave the current value unchanged
-- Set to `Some(n)`: Enable or change the duration (n > 0)
-- Set to `None`: Disable disappearing messages
+> **API note (not on-wire)**: Implementations that expose an update API for the Marmot Group Data Extension SHOULD allow callers to leave `disappearing_message_secs` unspecified to preserve the current value, distinct from explicitly setting it to `None` (disable) or `Some(n)` (enable/change). This tri-state distinction is purely an application-layer convenience — the on-wire encoding always contains either `None` or `Some(n)`.
 
 **NIP-40 expiration tags**: When a group has `disappearing_message_secs` set, implementations MUST auto-apply a [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) `expiration` tag to the outer `kind: 445` wrapper event. The expiration timestamp MUST be computed as `rumor.created_at + disappearing_message_secs`. Any caller-supplied expiration tag MUST be replaced by the auto-computed one to prevent conflicting expiration values. See [MIP-03](03.md) for the complete Group Event structure.
 

--- a/03.md
+++ b/03.md
@@ -31,7 +31,7 @@ Group Events use ephemeral keypairs and encrypted content to protect member iden
 }
 ```
 
-> **Note**: The `expiration` tag is only present when the group has disappearing messages enabled (`disappearing_message_secs` is set in the Marmot Group Data Extension). In this example, the expiration is computed from `rumor.created_at` (1693876700) + 3600 seconds = 1693880300. Groups without disappearing messages omit this tag.
+> **Note**: The `expiration` tag is only present when the group has disappearing messages enabled (`disappearing_message_secs` is set in the Marmot Group Data Extension). In this example, the expiration is computed from the inner `rumor.created_at` (not the outer event's `created_at` shown above — they may differ if the message is published after creation) + `disappearing_message_secs`. Assuming `rumor.created_at` = 1693876700 and `disappearing_message_secs` = 3600, the expiration is 1693876700 + 3600 = 1693880300. Groups without disappearing messages omit this tag.
 
 ### Field Details
 
@@ -257,6 +257,8 @@ When a group has `disappearing_message_secs` set in the Marmot Group Data Extens
 - **Expiration timestamp**: Computed as `rumor.created_at + disappearing_message_secs`
 - **Auto-application**: Implementations MUST automatically compute and apply this tag. Any caller-supplied expiration tag MUST be replaced by the auto-computed one to prevent conflicting values.
 - **Relay hint only**: The `expiration` tag is a hint to relays that the event can be discarded after the specified time. Relay compliance is not guaranteed.
+
+When `disappearing_message_secs` is **not set** (i.e., `None`), implementations MUST remove any caller-supplied `expiration` tag from `kind: 445` events before signing, so that the on-wire behavior is fully determined by group state.
 
 **Client-side deletion**: Clients are responsible for deleting expired messages from local storage. The protocol does not enforce automatic deletion — clients SHOULD implement expiration sweeps or deletion APIs. See [MIP-01](01.md) for the local deletion API recommendations.
 

--- a/03.md
+++ b/03.md
@@ -31,7 +31,7 @@ Group Events use ephemeral keypairs and encrypted content to protect member iden
 }
 ```
 
-> **Note**: The `expiration` tag is only present when the group has disappearing messages enabled (`disappearing_message_duration_secs` is set in the Marmot Group Data Extension). In this example, the expiration is `created_at` (1693876700) + 3600 seconds = 1693880300. Groups without disappearing messages omit this tag.
+> **Note**: The `expiration` tag is only present when the group has disappearing messages enabled (`disappearing_message_duration_secs` is set in the Marmot Group Data Extension). In this example, the expiration is computed from `rumor.created_at` (1693876700) + 3600 seconds = 1693880300. Groups without disappearing messages omit this tag.
 
 ### Field Details
 

--- a/03.md
+++ b/03.md
@@ -23,18 +23,24 @@ Group Events use ephemeral keypairs and encrypted content to protect member iden
   "created_at": 1693876700,
   "pubkey": "b2c4d6e8f0a1b3c5d7e9f1a3b5c7d9e1f3a5b7c9d1e3f5a7b9c1d3e5f7a9b1c3",
   "content": "Sj+MLhudemBRxOL4stTxo8XnCRstT2qMDh87XXqcLk9ggaPF57nR86XH6bHT9afJ4bPV96nB4/W32fGjtcfZ4fOlt48aKzxNXm96i5wNHi86S1w=",
-  "tags": [["h", "group_id_from_nostr_extension"]],
+  "tags": [
+    ["h", "group_id_from_nostr_extension"],
+    ["expiration", "1693880300"]
+  ],
   "sig": "506070809..."
 }
 ```
 
+> **Note**: The `expiration` tag is only present when the group has disappearing messages enabled (`disappearing_message_duration_secs` is set in the Marmot Group Data Extension). In this example, the expiration is `created_at` (1693876700) + 3600 seconds = 1693880300. Groups without disappearing messages omit this tag.
+
 ### Field Details
 
-| Field     | Description                                                                                                                                                                                                                                                                      | Encoding / Format                                 |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| `content` | Serialized [`MLSMessage`](https://www.rfc-editor.org/rfc/rfc9420.html#section-6-4) encrypted with ChaCha20-Poly1305. `content` MUST be `base64(nonce \|\| ciphertext)` where `ciphertext` is the full output of `ChaCha20-Poly1305.encrypt` and includes the authentication tag. | Base64 (standard, with padding).                  |
-| `pubkey`  | Ephemeral public key (different for each Group Event). MUST NOT be reused across events.                                                                                                                                                                                         | 32-byte secp256k1 x-only public key, hex-encoded. |
-| `h` tag   | Group ID from the Marmot Group Data Extension (`nostr_group_id`). Used for relay routing and group message filtering.                                                                                                                                                            | 32-byte value, hex-encoded.                       |
+| Field            | Description                                                                                                                                                                                                                                                                      | Encoding / Format                                 |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `content`        | Serialized [`MLSMessage`](https://www.rfc-editor.org/rfc/rfc9420.html#section-6-4) encrypted with ChaCha20-Poly1305. `content` MUST be `base64(nonce \|\| ciphertext)` where `ciphertext` is the full output of `ChaCha20-Poly1305.encrypt` and includes the authentication tag. | Base64 (standard, with padding).                  |
+| `pubkey`         | Ephemeral public key (different for each Group Event). MUST NOT be reused across events.                                                                                                                                                                                         | 32-byte secp256k1 x-only public key, hex-encoded. |
+| `h` tag          | Group ID from the Marmot Group Data Extension (`nostr_group_id`). Used for relay routing and group message filtering.                                                                                                                                                            | 32-byte value, hex-encoded.                       |
+| `expiration` tag | (Optional) [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) expiration timestamp. Auto-applied when the group has `disappearing_message_duration_secs` set (see [MIP-01](01.md)). Value is `rumor.created_at + duration_secs`. Hints to relays that the event can be discarded after this time.  | Unix timestamp as string.                         |
 
 ## Encryption Details
 
@@ -244,6 +250,21 @@ This approach provides the best of both worlds:
 - MUST NOT include `h` tags or other group identifiers
 - This ensures leaked events cannot be published to public relays
 
+### Disappearing Messages
+
+When a group has `disappearing_message_duration_secs` set in the Marmot Group Data Extension ([MIP-01](01.md)), Group Events for application messages MUST include a [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) `expiration` tag on the outer `kind: 445` wrapper event:
+
+- **Expiration timestamp**: Computed as `rumor.created_at + disappearing_message_duration_secs`
+- **Auto-application**: Implementations MUST automatically compute and apply this tag. Any caller-supplied expiration tag MUST be replaced by the auto-computed one to prevent conflicting values.
+- **Relay hint only**: The `expiration` tag is a hint to relays that the event can be discarded after the specified time. Relay compliance is not guaranteed.
+
+**Client-side deletion**: Clients are responsible for deleting expired messages from local storage. The protocol does not enforce automatic deletion — clients SHOULD implement expiration sweeps or deletion APIs. See [MIP-01](01.md) for the local deletion API recommendations.
+
+**Known limitations**:
+- Media files referenced by expired messages are not automatically deleted from Blossom servers
+- Group members may retain message content beyond the expiration time
+- NIP-40 relay compliance is best-effort
+
 ### Example Flow
 
 1. **Create**: Member creates a `kind: 9` chat message event (unsigned)
@@ -273,6 +294,7 @@ This approach provides the best of both worlds:
 - **CRITICAL**: ChaCha20-Poly1305 encryption with `encryption_key = MLS-Exporter("marmot", "group-event", 32)`, empty-byte-string AAD, and random nonce per event
 - Identity verification for inner events (unsigned to prevent leaks)
 - Ephemeral keypairs (never reuse) for privacy protection
+- NIP-40 expiration tag auto-application on kind: 445 events when group has `disappearing_message_duration_secs` set (see [MIP-01](01.md))
 
 ### Group Hygiene
 

--- a/03.md
+++ b/03.md
@@ -31,7 +31,7 @@ Group Events use ephemeral keypairs and encrypted content to protect member iden
 }
 ```
 
-> **Note**: The `expiration` tag is only present when the group has disappearing messages enabled (`disappearing_message_duration_secs` is set in the Marmot Group Data Extension). In this example, the expiration is computed from `rumor.created_at` (1693876700) + 3600 seconds = 1693880300. Groups without disappearing messages omit this tag.
+> **Note**: The `expiration` tag is only present when the group has disappearing messages enabled (`disappearing_message_secs` is set in the Marmot Group Data Extension). In this example, the expiration is computed from `rumor.created_at` (1693876700) + 3600 seconds = 1693880300. Groups without disappearing messages omit this tag.
 
 ### Field Details
 
@@ -40,7 +40,7 @@ Group Events use ephemeral keypairs and encrypted content to protect member iden
 | `content`        | Serialized [`MLSMessage`](https://www.rfc-editor.org/rfc/rfc9420.html#section-6-4) encrypted with ChaCha20-Poly1305. `content` MUST be `base64(nonce \|\| ciphertext)` where `ciphertext` is the full output of `ChaCha20-Poly1305.encrypt` and includes the authentication tag. | Base64 (standard, with padding).                  |
 | `pubkey`         | Ephemeral public key (different for each Group Event). MUST NOT be reused across events.                                                                                                                                                                                         | 32-byte secp256k1 x-only public key, hex-encoded. |
 | `h` tag          | Group ID from the Marmot Group Data Extension (`nostr_group_id`). Used for relay routing and group message filtering.                                                                                                                                                            | 32-byte value, hex-encoded.                       |
-| `expiration` tag | (Optional) [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) expiration timestamp. Auto-applied when the group has `disappearing_message_duration_secs` set (see [MIP-01](01.md)). Value is `rumor.created_at + duration_secs`. Hints to relays that the event can be discarded after this time.  | Unix timestamp as string.                         |
+| `expiration` tag | (Optional) [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) expiration timestamp. Auto-applied when the group has `disappearing_message_secs` set (see [MIP-01](01.md)). Value is `rumor.created_at + disappearing_message_secs`. Hints to relays that the event can be discarded after this time.  | Unix timestamp as string.                         |
 
 ## Encryption Details
 
@@ -252,9 +252,9 @@ This approach provides the best of both worlds:
 
 ### Disappearing Messages
 
-When a group has `disappearing_message_duration_secs` set in the Marmot Group Data Extension ([MIP-01](01.md)), Group Events for application messages MUST include a [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) `expiration` tag on the outer `kind: 445` wrapper event:
+When a group has `disappearing_message_secs` set in the Marmot Group Data Extension ([MIP-01](01.md)), Group Events for application messages MUST include a [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) `expiration` tag on the outer `kind: 445` wrapper event:
 
-- **Expiration timestamp**: Computed as `rumor.created_at + disappearing_message_duration_secs`
+- **Expiration timestamp**: Computed as `rumor.created_at + disappearing_message_secs`
 - **Auto-application**: Implementations MUST automatically compute and apply this tag. Any caller-supplied expiration tag MUST be replaced by the auto-computed one to prevent conflicting values.
 - **Relay hint only**: The `expiration` tag is a hint to relays that the event can be discarded after the specified time. Relay compliance is not guaranteed.
 
@@ -294,7 +294,7 @@ When a group has `disappearing_message_duration_secs` set in the Marmot Group Da
 - **CRITICAL**: ChaCha20-Poly1305 encryption with `encryption_key = MLS-Exporter("marmot", "group-event", 32)`, empty-byte-string AAD, and random nonce per event
 - Identity verification for inner events (unsigned to prevent leaks)
 - Ephemeral keypairs (never reuse) for privacy protection
-- NIP-40 expiration tag auto-application on kind: 445 events when group has `disappearing_message_duration_secs` set (see [MIP-01](01.md))
+- NIP-40 expiration tag auto-application on kind: 445 events when group has `disappearing_message_secs` set (see [MIP-01](01.md))
 
 ### Group Hygiene
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,7 @@ When working on protocol specifications, ensure these are always addressed:
   - NIP-01: Basic protocol flow
   - NIP-44: Encrypted Direct Message (used by NIP-59 for Welcome events; **not** used for kind: 445 group events)
   - NIP-59: Gift Wrap (Welcome event encryption)
+  - NIP-40: Expiration Timestamp (auto-applied on kind: 445 events for disappearing-message groups)
   - NIP-70: Protected Events (optional `-` tag for KeyPackage author enforcement)
   - NIP-09: Event deletion (optional, for complete KeyPackage removal only — not for rotation)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Breaking changes
 
+- **Extension v3 — disappearing messages**: Marmot Group Data Extension bumped from v2 to v3, adding `disappearing_message_secs` field. Kind:445 senders MUST auto-apply a NIP-40 `expiration` tag (computed from the inner rumor's `created_at`) when the group has a nonzero duration. Implementations MUST strip caller-supplied expiration tags when the group does not enable disappearing messages. ([MIP-01](01.md), [MIP-03](03.md))
 - **Encoding format**: KeyPackage (kind:443) and Welcome (kind:444) events now require base64 encoding for the `content` field. The `encoding` tag MUST be `["encoding", "base64"]`. Hex encoding was used by early implementations but is no longer supported. Implementations MUST reject events with missing or non-base64 `encoding` tags.
 - **KeyPackage migration**: `kind:30443` is now the canonical KeyPackage format. The Marmot rollout plan, including the May 1, 2026, at 00:00:00 UTC cutover guidance, is documented in [docs/migrations/2026-05-01-kind-30443-cutover.md](docs/migrations/2026-05-01-kind-30443-cutover.md).
 - **MIP-05 token size**: `EncryptedToken` expanded from 280 to 1084 bytes (`TokenPlaintext` from 220 to 1024 bytes) to accommodate larger FCM tokens and future UnifiedPush support. Platform-specific `token_length` validation replaced with a universal range of 1–1021. Batch recommendation lowered from 100 to 25 tokens per `kind:446` event.
@@ -36,6 +37,8 @@
 - **Encrypted media previews**: [MIP-04](04.md) now documents optional `thumbhash` `imeta` tags alongside `blurhash`, recommends emitting `thumbhash` in new implementations, requires receivers to parse both preview hash fields, and notes that `blurhash` remains only for backward compatibility in this version. ([#64](https://github.com/marmot-protocol/marmot/pull/64))
 
 ### Added
+
+- **Threat model T.3.6**: New threat entry for disappearing-message non-compliance — a member's client ignoring local deletion timers. ([threat_model.md](threat_model.md))
 
 ### Fixed
 

--- a/data_flows.md
+++ b/data_flows.md
@@ -121,7 +121,7 @@ sequenceDiagram
 
     A->>A: Build Marmot Group<br/>Data Extension
 
-    Note over A: Extension fields:<br/>- version: 2<br/>- nostr_group_id (random 32 bytes)<br/>- name, description<br/>- admin_pubkeys (raw 32-byte keys)<br/>- relays (length-prefixed URLs)<br/>- image fields (optional)
+    Note over A: Extension fields:<br/>- version: 3<br/>- nostr_group_id (random 32 bytes)<br/>- name, description<br/>- admin_pubkeys (raw 32-byte keys)<br/>- relays (length-prefixed URLs)<br/>- image fields (optional)<br/>- disappearing_message_duration_secs (optional)
 
     A->>MLS: Add extension to<br/>GroupContext
 
@@ -263,7 +263,7 @@ sequenceDiagram
 
     S->>S: Generate fresh<br/>ephemeral keypair
 
-    S->>S: Create kind: 445 event<br/>ephemeral pubkey<br/>content: base64(nonce||ciphertext)<br/>h tag: nostr_group_id (routing)
+    S->>S: Create kind: 445 event<br/>ephemeral pubkey<br/>content: base64(nonce||ciphertext)<br/>h tag: nostr_group_id (routing)<br/>expiration tag (if disappearing msgs)
 
     S->>R: Publish Group Event (445)
 
@@ -434,7 +434,7 @@ sequenceDiagram
 
     A->>A: Create updated<br/>Marmot Group Data Extension
 
-    Note over A: Updated fields:<br/>- name or description<br/>- relays list<br/>- nostr_group_id<br/>- admin_pubkeys
+    Note over A: Updated fields:<br/>- name or description<br/>- relays list<br/>- nostr_group_id<br/>- admin_pubkeys<br/>- disappearing_message_duration_secs
 
     A->>MLS: Create GroupContextExtensions<br/>Proposal
 

--- a/data_flows.md
+++ b/data_flows.md
@@ -121,7 +121,7 @@ sequenceDiagram
 
     A->>A: Build Marmot Group<br/>Data Extension
 
-    Note over A: Extension fields:<br/>- version: 3<br/>- nostr_group_id (random 32 bytes)<br/>- name, description<br/>- admin_pubkeys (raw 32-byte keys)<br/>- relays (length-prefixed URLs)<br/>- image fields (optional)<br/>- disappearing_message_duration_secs (optional)
+    Note over A: Extension fields:<br/>- version: 3<br/>- nostr_group_id (random 32 bytes)<br/>- name, description<br/>- admin_pubkeys (raw 32-byte keys)<br/>- relays (length-prefixed URLs)<br/>- image fields (optional)<br/>- disappearing_message_secs (optional)
 
     A->>MLS: Add extension to<br/>GroupContext
 
@@ -434,7 +434,7 @@ sequenceDiagram
 
     A->>A: Create updated<br/>Marmot Group Data Extension
 
-    Note over A: Updated fields:<br/>- name or description<br/>- relays list<br/>- nostr_group_id<br/>- admin_pubkeys<br/>- disappearing_message_duration_secs
+    Note over A: Updated fields:<br/>- name or description<br/>- relays list<br/>- nostr_group_id<br/>- admin_pubkeys<br/>- disappearing_message_secs
 
     A->>MLS: Create GroupContextExtensions<br/>Proposal
 

--- a/threat_model.md
+++ b/threat_model.md
@@ -313,6 +313,15 @@ Group members have access to all group state, including cryptographic secrets an
   - For sensitive conversations, rotate group membership periodically
   - Remove members who no longer need access promptly
 
+#### T.3.5 - Fake Proposals
+
+- **Description**: Members create proposals that waste bandwidth and processing time.
+- **Impact**: Resource exhaustion, though proposals require admin commitment to take effect.
+- **Countermeasures**:
+  - Admins can ignore or reject malicious proposals
+  - Client-side proposal validation and filtering
+  - Remove members who abuse proposal system
+
 #### T.3.6 - Disappearing Message Non-Compliance
 
 - **Description**: Disappearing messages (configured via `disappearing_message_duration_secs` in the Marmot Group Data Extension, [MIP-01](01.md)) are a best-effort feature. Members can modify their client to ignore expiration or retain messages beyond the configured duration. Relay operators may not honor [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) expiration tags, continuing to store and serve events after expiry.
@@ -325,15 +334,6 @@ Group members have access to all group state, including cryptographic secrets an
   - Users should understand that disappearing messages reduce casual retention, not guarantee cryptographic erasure
   - Media files referenced by expired messages are NOT automatically deleted from Blossom servers — this is a known limitation
 - **Residual Risk**: Malicious or non-compliant members can always retain message content. Disappearing messages provide a social norm and best-effort cleanup, not a cryptographic guarantee.
-
-#### T.3.5 - Fake Proposals
-
-- **Description**: Members create proposals that waste bandwidth and processing time.
-- **Impact**: Resource exhaustion, though proposals require admin commitment to take effect.
-- **Countermeasures**:
-  - Admins can ignore or reject malicious proposals
-  - Client-side proposal validation and filtering
-  - Remove members who abuse proposal system
 
 ### 2.4 Group Administrators
 

--- a/threat_model.md
+++ b/threat_model.md
@@ -324,7 +324,7 @@ Group members have access to all group state, including cryptographic secrets an
 
 #### T.3.6 - Disappearing Message Non-Compliance
 
-- **Description**: Disappearing messages (configured via `disappearing_message_duration_secs` in the Marmot Group Data Extension, [MIP-01](01.md)) are a best-effort feature. Members can modify their client to ignore expiration or retain messages beyond the configured duration. Relay operators may not honor [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) expiration tags, continuing to store and serve events after expiry.
+- **Description**: Disappearing messages (configured via `disappearing_message_secs` in the Marmot Group Data Extension, [MIP-01](01.md)) are a best-effort feature. Members can modify their client to ignore expiration or retain messages beyond the configured duration. Relay operators may not honor [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) expiration tags, continuing to store and serve events after expiry.
 - **Impact**: Messages intended to disappear may persist indefinitely on some clients or relays, undermining the privacy expectations of group members.
 - **Affected Components**: [MIP-01](01.md) (Disappearing Messages), [MIP-03](03.md) (Group Events, expiration tag)
 - **Countermeasures**:

--- a/threat_model.md
+++ b/threat_model.md
@@ -313,6 +313,19 @@ Group members have access to all group state, including cryptographic secrets an
   - For sensitive conversations, rotate group membership periodically
   - Remove members who no longer need access promptly
 
+#### T.3.6 - Disappearing Message Non-Compliance
+
+- **Description**: Disappearing messages (configured via `disappearing_message_duration_secs` in the Marmot Group Data Extension, [MIP-01](01.md)) are a best-effort feature. Members can modify their client to ignore expiration or retain messages beyond the configured duration. Relay operators may not honor [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) expiration tags, continuing to store and serve events after expiry.
+- **Impact**: Messages intended to disappear may persist indefinitely on some clients or relays, undermining the privacy expectations of group members.
+- **Affected Components**: [MIP-01](01.md) (Disappearing Messages), [MIP-03](03.md) (Group Events, expiration tag)
+- **Countermeasures**:
+  - Disappearing messages are cooperative — all participants must use compliant clients for full effectiveness
+  - NIP-40 expiration tags provide relay-side hints but compliance is not guaranteed
+  - SQLite implementations SHOULD enable `PRAGMA secure_delete = ON` to overwrite deleted message content on disk, reducing forensic recoverability
+  - Users should understand that disappearing messages reduce casual retention, not guarantee cryptographic erasure
+  - Media files referenced by expired messages are NOT automatically deleted from Blossom servers — this is a known limitation
+- **Residual Risk**: Malicious or non-compliant members can always retain message content. Disappearing messages provide a social norm and best-effort cleanup, not a cryptographic guarantee.
+
 #### T.3.5 - Fake Proposals
 
 - **Description**: Members create proposals that waste bandwidth and processing time.
@@ -478,6 +491,8 @@ A compromised client device represents a severe threat with access to all stored
   - Limit message retention on devices
   - Encrypt message storage
   - Delete messages when no longer needed
+  - Enable `PRAGMA secure_delete = ON` in SQLite to overwrite deleted content on disk, reducing forensic recoverability of expired or deleted messages
+  - Configure disappearing messages ([MIP-01](01.md)) to automatically reduce the retention window
   - Forward secrecy limits exposure if device was removed previously
 
 #### T.5.7 - Nostr Key Compromise Cross-Application Impact


### PR DESCRIPTION
![marmot](https://blossom.primal.net/29b673b6066cd360ce611ac6d833c77628305494e5deb052fe12ed690ee8baf4.jpg)

Spec update to match marmot-protocol/mdk#253, which wires disappearing messages through the full MDK stack.

## Changes

**MIP-01 (Group Construction & Extension)**
- Extension version bumped from 2 to 3
- New field: `disappearing_message_duration_secs` (0 or 8 bytes, big-endian uint64)
- TLS structure, field table, version history, and pseudocode all updated
- New "Disappearing Messages" section covering semantics, validation (zero rejected), tri-state updates, NIP-40 tagging, local deletion, and backward compatibility
- New groups MUST use version 3; v1/v2 groups deserialize the field as None

**MIP-03 (Group Messages)**
- `expiration` tag added to the Group Event field table and JSON example
- New "Disappearing Messages" section: auto-computed NIP-40 expiration tag on kind:445 when the group has a duration set, known limitations
- Implementation requirements updated

**data_flows.md**
- Group creation diagram shows version 3 with the new optional field
- Application message flow includes the expiration tag step
- Metadata update flow lists the new field

**threat_model.md**
- New T.3.6 (Disappearing Message Non-Compliance): cooperative feature, relay NIP-40 compliance not guaranteed, secure_delete recommendation, media cleanup gap
- T.5.6 updated with `PRAGMA secure_delete = ON` and disappearing message cross-reference

**AGENTS.md**
- NIP-40 added to key NIPs list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Groups now support per-group disappearing messages; new groups use the v3 group format and validate configured durations (zero disallowed).

* **Documentation**
  * Added disappearing-message semantics (enable/disable/change), automatic application/replacement of expiration tags on group messages, client deletion guidance, limitations, threat-model updates, and updated flows and implementation checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->