### PR TITLE
fix(MIP-03): rate-limit self-update Commits to prevent epoch-advance spam

### DIFF
--- a/03.md
+++ b/03.md
@@ -302,7 +302,7 @@ When `disappearing_message_secs` is **not set** (i.e., `None`), implementations 
 
 - Admin verification for Commit messages that are not self-updates or SelfRemove-only, with race condition handling
 - Self-update Commit validation (must contain only sender's own Update proposal — no other proposal types)
-- Self-update Commit rate limiting: throttle outbound self-updates to no faster than once per 60 seconds (except for security events such as nonce-reuse), and throttle the processing of inbound self-updates per sender on the same time scale (see Self-update Commit rate limiting)
+- Per-sender self-update Commit throttling: implement the outbound spacing and inbound processing controls described in Self-update Commit rate limiting. The 60-second default, SHOULD-level requirements, and security-event exceptions (e.g., nonce-reuse) are defined in that section
 - SelfRemove proposal support: sending, receiving, verification, and committing (see [MLS Extensions draft](https://datatracker.ietf.org/doc/draft-ietf-mls-extensions/))
 - Admin SelfRemove restriction: reject SelfRemove proposals from members in `admin_pubkeys`; admins MUST self-demote via GroupContextExtensions update before departing
 - Admin depletion prevention: a Commit containing SelfRemove proposals MUST be rejected if it would leave zero active admins (cross-reference `admin_pubkeys` against actual group membership)

--- a/03.md
+++ b/03.md
@@ -137,6 +137,17 @@ A self-update Commit is one where the committer updates only their own key mater
 - Self-update Commits MUST contain only an Update proposal for the committer's own LeafNode
 - Self-update Commits MUST NOT include any other proposals (Add, Remove, SelfRemove, GroupContextExtensions, etc.)
 
+**Self-update Commit rate limiting**:
+
+A self-update Commit advances the group epoch, forcing every member to derive a new exporter secret, update MLS group state, and re-derive the ChaCha20-Poly1305 key used for `kind: 445` events. Without a rate limit, a single member can impose O(N) cryptographic work on the group at O(1) cost to themselves — an asymmetric denial-of-service vector (see [threat_model.md](threat_model.md) T.3.7).
+
+- Senders SHOULD NOT issue self-update Commits more frequently than once per 60 seconds, except in response to a detected security event such as nonce-reuse (see [Edge Cases and Failure Modes](#edge-cases-and-failure-modes)) or a known device compromise
+- Receivers SHOULD throttle the *processing* of inbound self-update Commits on a per-sender basis — for example, by deferring the CPU-intensive key-derivation work so that one misbehaving sender cannot saturate the local processor. Throttling smooths instantaneous load; commits accepted by the [Commit Message Race Conditions](#commit-message-race-conditions) rules MUST still be applied in order so that group state remains consistent across all clients. Receivers MUST NOT silently drop or skip a self-update Commit purely because it arrived faster than the rate limit
+- Clients SHOULD warn the local user before issuing a self-update Commit if the same client already issued one within the previous 60 seconds, to prevent accidental over-rotation
+- Admins SHOULD treat sustained rate-limit violation by a member as evidence of malicious behavior and remove the offending member via an MLS Remove proposal/Commit
+
+The 60-second floor is a default. Future revisions of [MIP-01](01.md) (Marmot Group Data Extension) MAY allow admins to configure a per-group rate limit; until such a field is defined, the default in this section applies.
+
 **SelfRemove Commits**:
 
 A SelfRemove Commit processes one or more pending SelfRemove proposals. Any member (admin or non-admin) MAY create a SelfRemove Commit. This enables members to leave groups without waiting for an admin to come online.
@@ -173,6 +184,7 @@ When an admin wishes to leave the group, they MUST relinquish admin status befor
 **Security requirements**:
 
 - For self-update Commits: Clients MUST verify the Commit contains ONLY an Update proposal for the sender's own LeafNode — no other proposal types
+- For self-update Commits: Clients SHOULD throttle inbound self-update Commits per sender so that no single member forces more than one epoch advance per 60 seconds of local processing time, and SHOULD warn the user before issuing a self-update if one was already issued by them within the last 60 seconds (see Self-update Commit rate limiting above)
 - For SelfRemove-only Commits: Clients MUST verify the Commit contains ONLY SelfRemove proposals by reference — no other proposal types
 - When building a Commit that includes SelfRemove proposals, the committer MUST verify that none of the referenced proposals are from members whose public key is in the current epoch's `admin_pubkeys`. If any are, those proposals MUST be excluded from the Commit
 - For all other Commits: Sender MUST be listed in `admin_pubkeys` (see [MIP-01](01.md))
@@ -290,6 +302,7 @@ When `disappearing_message_secs` is **not set** (i.e., `None`), implementations 
 
 - Admin verification for Commit messages that are not self-updates or SelfRemove-only, with race condition handling
 - Self-update Commit validation (must contain only sender's own Update proposal — no other proposal types)
+- Self-update Commit rate limiting: throttle outbound self-updates to no faster than once per 60 seconds (except for security events such as nonce-reuse), and throttle the processing of inbound self-updates per sender on the same time scale (see Self-update Commit rate limiting)
 - SelfRemove proposal support: sending, receiving, verification, and committing (see [MLS Extensions draft](https://datatracker.ietf.org/doc/draft-ietf-mls-extensions/))
 - Admin SelfRemove restriction: reject SelfRemove proposals from members in `admin_pubkeys`; admins MUST self-demote via GroupContextExtensions update before departing
 - Admin depletion prevention: a Commit containing SelfRemove proposals MUST be rejected if it would leave zero active admins (cross-reference `admin_pubkeys` against actual group membership)

--- a/threat_model.md
+++ b/threat_model.md
@@ -335,6 +335,16 @@ Group members have access to all group state, including cryptographic secrets an
   - Media files referenced by expired messages are NOT automatically deleted from Blossom servers — this is a known limitation
 - **Residual Risk**: Malicious or non-compliant members can always retain message content. Disappearing messages provide a social norm and best-effort cleanup, not a cryptographic guarantee.
 
+#### T.3.7 - Epoch-Advance Spam via Self-Update Commits
+
+- **Description**: A non-admin group member sends a high-frequency stream of self-update Commits. Each Commit advances the MLS epoch, forcing every other member to derive a new exporter secret, update MLS group state, and re-derive the ChaCha20-Poly1305 key used for `kind: 445` events. The attacker pays O(1) per Commit; the rest of the group pays O(N).
+- **Impact**: Asymmetric denial of service. A single misbehaving member in a 50-member group can impose roughly 50× their own cryptographic work on the group, overwhelming mobile or low-power clients in particular. This is distinct from T.4.7 (which covers the same pattern from admins) and from T.3.1 (application-message spam, which does not advance the epoch); the O(N) amplification on every single Commit is what makes self-update spam particularly damaging.
+- **Countermeasures**:
+  - Sender-side rate limit: members SHOULD NOT issue self-update Commits more frequently than once per 60 seconds, except in response to a detected security event (see [MIP-03](03.md))
+  - Receiver-side throttling: clients SHOULD defer the CPU-intensive key derivation triggered by inbound self-update Commits on a per-sender basis, smoothing instantaneous load without skipping commits accepted by the race-condition rules
+  - Detection-and-response: admins SHOULD treat sustained rate-limit violation as evidence of malicious behavior and remove the offending member via an MLS Remove operation
+  - Client UX: warn the local user before issuing a self-update Commit if one was already issued within the last 60 seconds, to prevent accidental over-rotation
+
 ### 2.4 Group Administrators
 
 Group admins have all member capabilities plus additional privileges to modify group state.
@@ -415,6 +425,7 @@ Group admins have all member capabilities plus additional privileges to modify g
   - Client-side rate limiting
   - Admin removal if behavior detected
   - Client warnings for rapid admin actions
+  - For the equivalent attack from non-admins via self-update Commits (which any member can issue), see T.3.7
 
 #### T.4.8 - Malformed Proposal Commits
 
@@ -882,12 +893,12 @@ Various DoS vectors exist that can degrade service quality or exhaust resources.
 
 #### T.10.5 - Rapid State Changes
 
-- **Description**: Malicious admins commit updates at high frequency to overwhelm clients.
+- **Description**: Malicious admins commit updates at high frequency to overwhelm clients. The same epoch-advance amplification is also reachable by any non-admin member through self-update Commit spam — see T.3.7 for the dedicated treatment of that variant.
 - **Impact**: Client overwhelm, resource exhaustion, potential crashes.
 - **Countermeasures**:
-  - Client-side rate limiting for Commit processing
-  - Remove malicious admin if behavior detected
-  - Client warnings for rapid admin actions (See also T.4.7)
+  - Client-side rate limiting for self-update Commit processing per sender (default 60s floor per [MIP-03](03.md)), while preserving in-order application of accepted Commits. Admin Commits are intentionally excluded from this throttle so urgent admin recovery actions are not delayed
+  - Remove malicious admin or member if behavior detected
+  - Client warnings for rapid admin actions (See also T.4.7 for the admin variant and T.3.7 for the non-admin self-update variant)
 
 #### 2.10.3 Network-Level DoS
 
@@ -1474,6 +1485,14 @@ Common mistakes that developers should avoid when implementing Marmot:
 
 **Solution**: Perform self-update immediately after processing Welcome, before sending any application messages. Automate this in client implementations or provide prominent UI prompts. See [MIP-02](02.md) Post-Join Self-Update Requirement.
 
+#### 3.1.13 Unbounded Self-Update Commit Rate
+
+**Pitfall**: Treating self-update Commits as fully member-controlled and applying every inbound self-update immediately, regardless of how rapidly they arrive from a single sender. Because any member can self-update at will and each Commit advances the epoch, an attacker can pay O(1) per Commit while every other member pays O(N) in key derivations.
+
+**Consequences**: Asymmetric denial of service. Mobile and low-power clients in larger groups can be saturated by a single misbehaving member. See T.3.7.
+
+**Solution**: Throttle the *processing* of inbound self-update Commits on a per-sender basis (default: at most one epoch advance per 60 seconds of local processing time per sender), without dropping or skipping commits accepted by the race-condition rules. Throttle outbound self-updates the same way — and warn the user before issuing a second self-update within 60 seconds. Surface sustained rate-limit violations to admins so the offending member can be removed via an MLS Remove. See [MIP-03](03.md) Self-update Commit rate limiting.
+
 ### 3.2 Implementation Requirements
 
 Implementations MUST:
@@ -1496,6 +1515,7 @@ Implementations SHOULD:
 
 - Use multiple admins for groups to provide checks and balances
 - Implement client-side rate limiting and message filtering
+- Throttle self-update Commits per sender (default: no faster than one epoch advance per 60 seconds per sender) to prevent epoch-advance spam (See T.3.7)
 - Rotate `nostr_group_id` values periodically
 - Use multiple relays per group
 - Add random delays to obscure timing patterns


### PR DESCRIPTION
![marmot](https://blossom.primal.net/f8c32884248d083d4485635b733a4f71d41aa1701016d3f6e1485ba7104ebdac.jpg)

Relates to marmot-protocol/marmot-security#48

## What

Adds a default 60-second per-sender rate limit on self-update Commits, plus a receiver-side processing throttle. Updates the threat model with a new threat T.3.7 covering the matching attack vector.

## Why

Any group member can issue self-update Commits at will, and each one advances the MLS epoch. Every other member then has to derive a new exporter secret and re-derive the ChaCha20-Poly1305 key used for `kind: 445` events. Without a bound, a single misbehaving marmot pays O(1) per Commit while the rest of the colony pays O(N) — an asymmetric DoS that hits mobile clients hardest.

This is reported as marmot-security#48 (severity MEDIUM, MIP-03).

## How

- **MIP-03**: New "Self-update Commit rate limiting" block in the Self-update Commits section. Senders SHOULD throttle to once per 60 seconds (with a carve-out for security events such as nonce reuse). Receivers SHOULD throttle the *processing* of inbound self-updates per sender — but MUST NOT silently drop or skip any Commit accepted by the race-condition rules. Throttling smooths CPU load; the MLS commit chain is still applied in order, so group state stays consistent across clients. Admins SHOULD remove sustained violators.
- **threat_model.md**: New T.3.7 under §2.3.1, cross-referenced from T.4.7 and T.10.5 (which already covered the admin-initiated variant). New implementation pitfall §3.1.13 and a §3.3 best-practice bullet.
- **Future hook**: The 60-second floor is the default. A future Marmot Group Data Extension revision MAY make the limit admin-configurable; the spec text leaves room for that without forcing an extension version bump now.

## Why SHOULD and not MUST

A MUST-level reject would let compliant and non-compliant clients diverge on whether a Commit was applied — that forks group state. SHOULD-level throttling on processing keeps the chain consistent and just smooths the load curve. Removal of repeat offenders is the resolution path, not rejection.

## Out of scope

MDK implementation lands as a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated security requirements and threat model to add self-update commit rate limiting.
  * Added guidance to throttle inbound self-updates per sender and warn users before rapid outbound self-updates.
  * Clarified admin actions for sustained violations and protections against DoS from excessive self-update commits.
  * Specified a default 60-second minimum interval and added implementation checklist items for rate-limiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->