### PR TITLE
fix(MIP-01): specify HKDF-SHA256 for image key derivations

### DIFF
--- a/01.md
+++ b/01.md
@@ -167,6 +167,15 @@ The `relays` field is a variable-length vector of individually length-prefixed r
 
 The group image encryption uses ChaCha20-Poly1305 with key material derived via HKDF from seeds stored in the extension.
 
+**Hash function**: All HKDF operations in this MIP (image encryption key derivation and upload keypair derivation, including v1 backward-compatible derivations) MUST use **HKDF-SHA256** as defined in [RFC 5869](https://www.rfc-editor.org/rfc/rfc5869). This aligns with the hash function of the mandatory MLS ciphersuite `MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519` (`0x0001`) and ensures cross-implementation interoperability — implementations using a different hash (e.g., SHA-512) would derive incompatible keys and fail to decrypt the same group image.
+
+**Canonical encoding of HKDF inputs**: To guarantee byte-identical PRK and key derivations across implementations, the HKDF inputs MUST be encoded as follows:
+
+- **`salt`**: the empty octet string (zero bytes of length 0), written below as `salt=""`. Implementations MUST NOT pass a null/None value, since some crypto libraries map null to RFC 5869's "salt absent" default (a string of `HashLen` zero bytes), which produces a different PRK from an empty salt and breaks interoperability.
+- **`IKM`**: the raw 32-byte seed (`image_key` or `image_upload_key`) without any encoding, framing, or length prefix.
+- **`info`**: the UTF-8 byte encoding of the literal label string (e.g., `"mip01-image-encryption-v2"`), with no NUL terminator and no length prefix.
+- **Output length (`L`)**: the number of bytes shown in each call (32 for keys, 32 for the upload secret).
+
 **Encryption** (v2): When encrypting a group image:
 
 ```pseudocode
@@ -174,9 +183,9 @@ image_key = random(32)              // Cryptographically random encryption seed
 image_nonce = random(12)            // Cryptographically random nonce
 image_upload_key = random(32)       // Cryptographically random upload seed
 
-// Derive encryption key from seed using HKDF (Extract then Expand)
-prk = HKDF-Extract(salt=None, IKM=image_key)
-encryption_key = HKDF-Expand(prk, "mip01-image-encryption-v2", 32)
+// Derive encryption key from seed using HKDF-SHA256 (Extract then Expand)
+prk = HKDF-Extract-SHA256(salt="", IKM=image_key)
+encryption_key = HKDF-Expand-SHA256(prk, "mip01-image-encryption-v2", 32)
 
 encrypted_image = ChaCha20-Poly1305.encrypt(encryption_key, image_nonce, image_data)
 ```
@@ -188,8 +197,8 @@ The `image_key` field stores the seed, not the encryption key directly. This pro
 The Nostr keypair for Blossom upload authentication MUST be deterministically derived from the `image_upload_key` seed:
 
 ```pseudocode
-prk = HKDF-Extract(salt=None, IKM=image_upload_key)
-upload_secret = HKDF-Expand(prk, "mip01-blossom-upload-v2", 32)
+prk = HKDF-Extract-SHA256(salt="", IKM=image_upload_key)
+upload_secret = HKDF-Expand-SHA256(prk, "mip01-blossom-upload-v2", 32)
 upload_keypair = secp256k1_keypair_from_secret(upload_secret)
 ```
 
@@ -200,9 +209,9 @@ The `image_upload_key` is cryptographically independent from `image_key`, ensuri
 When an admin updates the group image:
 
 1. **Generate new seeds**: Create new random `image_key` (32 bytes), `image_nonce` (12 bytes), and `image_upload_key` (32 bytes)
-2. **Derive encryption key**: Compute `prk = HKDF-Extract(salt=None, IKM=image_key)`, then `encryption_key = HKDF-Expand(prk, "mip01-image-encryption-v2", 32)`
+2. **Derive encryption key**: Compute `prk = HKDF-Extract-SHA256(salt="", IKM=image_key)`, then `encryption_key = HKDF-Expand-SHA256(prk, "mip01-image-encryption-v2", 32)`
 3. **Encrypt new image**: Use ChaCha20-Poly1305 to encrypt the new group image with the derived key
-4. **Derive upload keypair**: Compute `prk = HKDF-Extract(salt=None, IKM=image_upload_key)`, then `upload_secret = HKDF-Expand(prk, "mip01-blossom-upload-v2", 32)` and derive the Nostr keypair
+4. **Derive upload keypair**: Compute `prk = HKDF-Extract-SHA256(salt="", IKM=image_upload_key)`, then `upload_secret = HKDF-Expand-SHA256(prk, "mip01-blossom-upload-v2", 32)` and derive the Nostr keypair
 5. **Upload to Blossom**: Upload the encrypted image using the derived keypair for authentication, obtaining `new_image_hash = SHA256(encrypted_image)`
 6. **Update extension**: Commit an MLS proposal updating `image_hash`, `image_key`, `image_nonce`, and `image_upload_key` fields
 7. **Cleanup old image**: After successful commit, derive the previous upload keypair from `old_image_upload_key` and request deletion of the old image blob from Blossom
@@ -337,7 +346,7 @@ function validate_structure(data, version) {
 **Version-Specific Implementation**:
 
 - **New Groups**: MUST create with version `3` format
-- **Version 1 Support**: Implementations SHOULD support reading version 1 extensions for backward compatibility. In version 1, `image_key` is used directly as the encryption key (not as an HKDF seed), `image_upload_key` is absent (the upload keypair is derived from `image_key` using context `"mip01-blossom-upload-v1"`), and admin pubkeys are hex-encoded strings
+- **Version 1 Support**: Implementations SHOULD support reading version 1 extensions for backward compatibility. In version 1, `image_key` is used directly as the encryption key (not as an HKDF seed), `image_upload_key` is absent (the upload keypair is derived from `image_key` using HKDF-SHA256 with context `"mip01-blossom-upload-v1"`), and admin pubkeys are hex-encoded strings
 - **Version 2 Support**: Implementations SHOULD support reading version 2 extensions for backward compatibility. Per the general append-only rule (see [Version Field](#version-field)), any v3+ fields absent from a v2 extension default to their absent value (e.g., `disappearing_message_secs` defaults to `None`)
 - **Future Versions**: SHOULD implement forward compatibility for unknown versions
 - **Error Handling**: MUST gracefully handle version mismatches with clear error messages
@@ -370,6 +379,6 @@ This MIP defines the foundation for creating secure, Nostr-integrated groups:
 - Admin verification for all extension updates including version changes
 - Compatibility checking before group creation
 - Private MLS group IDs (never publish to relays)
-- ChaCha20-Poly1305 encryption for group images with HKDF key derivation: `HKDF-Extract(salt=None, IKM=image_key)` then `HKDF-Expand(prk, "mip01-image-encryption-v2", 32)`
-- Deterministic upload keypair derivation using `HKDF-Extract(salt=None, IKM=image_upload_key)` then `HKDF-Expand(prk, "mip01-blossom-upload-v2", 32)` for Blossom authentication and cleanup
+- ChaCha20-Poly1305 encryption for group images with HKDF-SHA256 key derivation: `HKDF-Extract-SHA256(salt="", IKM=image_key)` then `HKDF-Expand-SHA256(prk, "mip01-image-encryption-v2", 32)`
+- Deterministic upload keypair derivation using `HKDF-Extract-SHA256(salt="", IKM=image_upload_key)` then `HKDF-Expand-SHA256(prk, "mip01-blossom-upload-v2", 32)` for Blossom authentication and cleanup
 - `disappearing_message_secs` validation: reject `0`, propagate through group creation/update/welcome flows, auto-apply NIP-40 expiration tag on kind: 445 events when enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 
 ### Fixed
 
+- **MIP-01 HKDF hash function and input encoding**: [MIP-01](01.md) now explicitly specifies **HKDF-SHA256** for all image encryption key and upload keypair derivations (v1 and v2), and pins canonical encoding of HKDF inputs: `salt` is the empty octet string (zero bytes, length 0, NOT a null/None value or RFC 5869's HashLen-zeros default), `info` labels are UTF-8 bytes with no terminator or length prefix. Previously the hash was unspecified and `salt=None` was ambiguous across crypto libraries, both producing different PRKs across implementations and breaking interoperability. Aligns with the mandatory MLS ciphersuite `0x0001`. ([#51](https://github.com/marmot-protocol/marmot-security/issues/51))
+
 ### Removed
 
 ### Deprecated


### PR DESCRIPTION
![marmot](https://blossom.primal.net/e07030feceea9c643d8f5e6b8196de51ebea6ad07b782bbba4870a9f31214d8c.jpg)

Closes marmot-protocol/marmot-security#51.

## What

MIP-01's Image Encryption section called for `HKDF-Extract` and `HKDF-Expand` without naming the hash function. Two compliant marmots could pick SHA-256 and SHA-512, derive different keys from the same `image_key`, and stare at each other's group photos as ciphertext mush.

This PR pins **HKDF-SHA256** (RFC 5869) for every HKDF call in MIP-01: both v2 derivations and the v1 backward-compatible upload-keypair derivation.

## Why SHA-256

It matches the hash of the mandatory MLS ciphersuite `MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519` (`0x0001`). Same hash family the rest of the spec already commits to.

## Changed

- `01.md`: added a "Hash function" subsection under Image Encryption pinning HKDF-SHA256 with rationale; renamed every pseudocode call to `HKDF-Extract-SHA256` / `HKDF-Expand-SHA256` (encryption, upload identity, update workflow, implementation requirements); v1 backward-compat note now names the hash too.
- `CHANGELOG.md`: entry under Unreleased / Fixed.

No wire-format change, no breaking change for any v1 or v2 implementation that already used SHA-256 (which is everyone shipping today, per MDK and marmot-ts).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/marmot/pull/68">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified base64 encoding requirements for KeyPackage and Welcome events.
  * Added support for optional thumbhash metadata tags; blurhash retained for backward compatibility.
  * Updated token sizing and validation limits.
  * Specified that image-encryption and upload-keypair derivations use HKDF-SHA256 and defined canonical HKDF input encoding (empty salt, UTF-8 info, 32-byte outputs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->