### PR TITLE
Add MIP-06 ephemeral live streams

### DIFF
--- a/06.md
+++ b/06.md
@@ -1,0 +1,336 @@
+# MIP-06
+
+## Ephemeral Live Streams
+
+`draft` `optional`
+
+This document defines an optional live-streaming overlay for Marmot groups. The
+overlay lets clients show low-latency, live-updating output while preserving
+normal [MIP-03](03.md) Group Messages as the durable history layer.
+
+The intended first use case is long generated output, such as AI assistant
+responses, transcription, or other progressive results. A live stream is
+temporary UI state. The final message remains a normal Marmot application
+message.
+
+## Overview
+
+Marmot already provides durable encrypted group messaging using MLS and Nostr.
+That path is the source of truth for sync, replay, search, backups, and history
+rebuilds. Some applications also need low-latency progress updates that should
+not create many permanent chat messages.
+
+This specification provides a three-part pattern:
+
+```text
+stream offer (MIP-03 Group Message) -> live transport frames -> final anchor (MIP-03 Group Message)
+```
+
+1. A sender publishes a normal encrypted Marmot message that announces and
+   authorizes a live stream.
+2. Participants exchange ephemeral frames over an out-of-band transport such as
+   QUIC or WebTransport.
+3. The sender publishes a final normal encrypted Marmot message containing the
+   durable result. Clients replace the live preview with this final message.
+
+Live streams are optional. Clients that do not implement this MIP still receive
+the final message and can ignore stream offers.
+
+## Non-Goals
+
+This MIP does not:
+
+- replace [MIP-03](03.md) Group Messages;
+- define a new durable history format;
+- require QUIC, WebTransport, or any other specific network transport;
+- replace QUIC's TLS 1.3 security model with MLS keys;
+- guarantee reliable delivery of every live frame.
+
+MLS is used to authorize the stream and derive stream-scoped application
+secrets. The out-of-band transport remains responsible for its own transport
+security.
+
+## Application Message Kinds
+
+All messages in this section are unsigned inner application events carried
+inside a [MIP-03](03.md) Group Event (`kind: 445`).
+
+| Kind | Name | Description |
+|------|------|-------------|
+| `450` | Stream Offer | Announces and authorizes an ephemeral live stream. |
+| `451` | Stream Final | Publishes the durable result and binds it to the stream. |
+
+These kinds are only meaningful inside Marmot Group Messages. They MUST remain
+unsigned like other MIP-03 inner application messages.
+
+## Stream Offer (kind 450)
+
+A stream offer announces that the sender may send ephemeral live frames for one
+piece of output.
+
+```json
+{
+  "kind": 450,
+  "created_at": 1693876700,
+  "pubkey": "<sender_nostr_pubkey>",
+  "content": "",
+  "tags": [
+    ["v", "mip06-v1"],
+    ["stream", "<stream_id>"],
+    ["purpose", "assistant-output"],
+    ["transport", "webtransport", "https://example.com/marmot-stream/<stream_id>"],
+    ["expires", "1693877000"],
+    ["max-bytes", "1048576"],
+    ["max-duration", "300"],
+    ["exporter-label", "marmot.live-stream.v1"]
+  ]
+}
+```
+
+### Tags
+
+| Tag | Description | Required |
+|-----|-------------|----------|
+| `v` | Version string. Current value: `mip06-v1`. | Yes |
+| `stream` | Random 128-bit or larger stream identifier, encoded as lowercase hex. | Yes |
+| `purpose` | Application purpose, such as `assistant-output`, `typing-preview`, or `transcription`. | Yes |
+| `transport` | Transport type and endpoint/candidate. Multiple tags MAY be present. | Yes |
+| `expires` | Unix timestamp after which receivers MUST reject new stream frames. | Yes |
+| `max-bytes` | Maximum total bytes accepted for this stream. | Yes |
+| `max-duration` | Maximum stream lifetime in seconds. | Yes |
+| `exporter-label` | MLS exporter label used for stream-scoped application secrets. | Yes |
+| `reply` | Optional event id or application id this stream previews. | No |
+| `mime` | Optional MIME type of streamed payload. | No |
+
+`stream_id` values MUST be unique for the sender within the current MLS epoch.
+Senders SHOULD generate at least 128 bits of randomness.
+
+### Transport Tags
+
+The first value after `transport` is the transport type. Remaining values are
+transport-specific.
+
+Examples:
+
+```text
+["transport", "webtransport", "https://example.com/marmot-stream/<stream_id>"]
+["transport", "quic", "host.example.com", "443", "alpn=marmot-live-v1"]
+["transport", "relay", "wss://relay.example.com/marmot-live"]
+```
+
+Clients MUST ignore unsupported transport types. If no supported transport is
+available, they SHOULD ignore the offer and wait for the final message.
+
+## Stream Secret Derivation
+
+Clients derive stream-scoped application material from the MLS exporter for the
+current epoch.
+
+```text
+stream_context =
+  "mip06-v1" || 0x00 ||
+  group_id || 0x00 ||
+  epoch || 0x00 ||
+  stream_id || 0x00 ||
+  sender_nostr_pubkey || 0x00 ||
+  purpose
+
+stream_secret = MLS-Exporter("marmot.live-stream.v1", stream_context, 32)
+```
+
+Implementations MAY use `stream_secret` for:
+
+- application-layer AEAD over live frame payloads;
+- a bearer token or MAC key that binds an out-of-band connection to the Marmot
+  group and epoch;
+- future MLS extension exporters when available.
+
+Implementations MUST NOT use `stream_secret` as a replacement for QUIC packet
+protection keys. Standard QUIC uses TLS 1.3 for transport security. MIP-06 only
+defines Marmot-level authorization and payload binding.
+
+If a Commit advances the group to a new epoch before the stream completes,
+receivers MUST reject further frames for the old epoch. Senders MAY publish a
+new Stream Offer in the new epoch.
+
+## Live Frame Format
+
+The live transport carries frame objects. Exact binary encoding is
+transport-specific, but implementations MUST preserve the following fields:
+
+```json
+{
+  "v": "mip06-v1",
+  "stream": "<stream_id>",
+  "seq": 12,
+  "type": "delta",
+  "content": "partial text",
+  "hash_prev": "<hex>",
+  "hash": "<hex>"
+}
+```
+
+| Field | Description | Required |
+|-------|-------------|----------|
+| `v` | Version string: `mip06-v1`. | Yes |
+| `stream` | Stream id from the Stream Offer. | Yes |
+| `seq` | Monotonic unsigned sequence number starting at `0`. | Yes |
+| `type` | Frame type. | Yes |
+| `content` | Frame payload. MAY be empty for control frames. | No |
+| `hash_prev` | Hash of the previous frame, hex-encoded. Empty for `seq = 0`. | Yes |
+| `hash` | Hash of this frame's canonical encoding, hex-encoded. | Yes |
+
+Frame types:
+
+| Type | Description |
+|------|-------------|
+| `begin` | Stream started. |
+| `delta` | Incremental content. |
+| `snapshot` | Replacement snapshot of current preview state. |
+| `ack` | Optional receiver acknowledgement. |
+| `reset` | Sender or receiver resets the preview. |
+| `done` | Stream completed; final anchor should follow. |
+| `error` | Stream failed; final anchor may still follow. |
+
+Receivers MUST treat frames as ephemeral preview state. They MUST NOT insert
+individual frames into durable chat history.
+
+## Stream Final (kind 451)
+
+The final message publishes the durable content and binds it to the live stream.
+
+```json
+{
+  "kind": 451,
+  "created_at": 1693876750,
+  "pubkey": "<sender_nostr_pubkey>",
+  "content": "Final assistant response text.",
+  "tags": [
+    ["v", "mip06-v1"],
+    ["stream", "<stream_id>"],
+    ["content-kind", "9"],
+    ["frames", "42"],
+    ["hash-final", "<hex>"],
+    ["hash-chain", "<hex>"]
+  ]
+}
+```
+
+### Tags
+
+| Tag | Description | Required |
+|-----|-------------|----------|
+| `v` | Version string: `mip06-v1`. | Yes |
+| `stream` | Stream id from the Stream Offer. | Yes |
+| `content-kind` | Durable application kind represented by `content`, commonly `9` for text. | Yes |
+| `frames` | Number of live frames sent, decimal encoded. | No |
+| `hash-final` | Hash of the final durable content, hex-encoded. | Yes |
+| `hash-chain` | Hash-chain tip of observed live frames, hex-encoded. | No |
+
+Clients that observed the stream SHOULD verify `hash-chain` against received
+frames when present. Verification failure MUST NOT cause the final message to be
+dropped; instead, the client SHOULD discard the preview state and display the
+final message as authoritative.
+
+Clients MUST treat the Stream Final as the durable source of truth. The UI MAY
+replace the live preview with the final content.
+
+## Receiver Behavior
+
+When a client receives a Stream Offer:
+
+1. Verify the offer is a valid MIP-03 application message from a current group
+   member.
+2. Verify version, `stream`, expiry, byte limit, duration limit, and supported
+   transport.
+3. Derive stream-scoped application material from the current MLS epoch.
+4. Connect to one supported transport if policy allows.
+5. Render received frames as temporary preview state only.
+
+When a client receives a Stream Final:
+
+1. Verify the final is a valid MIP-03 application message from the same sender.
+2. Verify `hash-final` against the final content.
+3. If a live preview exists, replace it with the final durable content.
+4. If no live preview exists, display the final content normally.
+
+## Sender Behavior
+
+Senders SHOULD:
+
+- publish the Stream Offer before sending live frames;
+- include conservative `expires`, `max-bytes`, and `max-duration` limits;
+- stop sending frames when the group epoch changes;
+- publish a Stream Final even if the live transport fails;
+- avoid using live streams for sensitive messages when timing privacy matters.
+
+Senders MUST NOT rely on live frames as durable delivery. The final application
+message is required for persistence.
+
+## Security Considerations
+
+### Durable History
+
+Live frames are not durable messages. Clients MUST NOT treat them as history,
+MUST NOT replay them as chat messages, and MUST NOT sync them as permanent
+content. The Stream Final is authoritative.
+
+### Transport Security
+
+This MIP does not replace QUIC/TLS, WebTransport security, or any other
+transport security model. MLS exporter material only binds the stream to the
+Marmot group and epoch at the application layer.
+
+### Metadata Leakage
+
+Live streams reveal more timing and size metadata than a single final Group
+Message. Observers may infer response duration, approximate output size, and
+interaction cadence.
+
+Clients SHOULD provide a setting to disable live streams. Implementations SHOULD
+rate-limit frames, coalesce deltas, and consider padding for sensitive uses.
+
+### Denial of Service
+
+Stream Offers MUST include expiry, byte, and duration limits. Receivers MUST
+enforce these limits and MUST be able to refuse streams. Clients SHOULD cap the
+number of concurrent streams per group and per sender.
+
+### Epoch Changes and Member Removal
+
+Because stream material is tied to the MLS epoch, receivers MUST reject frames
+for an old epoch after processing a Commit. Senders MUST stop old streams after
+membership changes. A removed member MUST NOT continue receiving live frames
+authorized by the old epoch.
+
+### Hash Chains
+
+Hash chains help detect preview tampering or dropped frames, but the final
+message remains authoritative. A hash-chain mismatch SHOULD clear the live
+preview and display the final message with a non-fatal warning.
+
+## Privacy Properties
+
+✅ Protects final content using normal Marmot/MLS Group Messages.
+
+✅ Keeps durable history compact and compatible with clients that do not support
+this MIP.
+
+✅ Lets applications provide low-latency progress without publishing many
+permanent Group Messages.
+
+⚠️ Leaks additional timing and approximate size metadata while the live stream is
+active.
+
+⚠️ Requires transport-specific NAT, relay, and mobile-backgrounding behavior
+outside the scope of this MIP.
+
+## Interoperability
+
+Clients that implement MIP-06 MUST accept unsupported transports gracefully.
+Clients that do not implement MIP-06 will ignore `kind: 450` offers and still
+process `kind: 451` finals as normal application messages if their application
+supports that final content kind.
+
+Applications SHOULD NOT make live streaming required for conversation
+correctness.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Required MIPs must be implemented for Marmot compatibility. Implementations may 
 | [MIP-03](03.md) | Group Messages | 👀 Review | ✅ Yes |
 | [MIP-04](04.md) | Encrypted Media | 👀 Review | ❌ No |
 | [MIP-05](05.md) | Push Notifications | 🚧 Draft | ❌ No |
+| [MIP-06](06.md) | Ephemeral Live Streams | 🚧 Draft | ❌ No |
 
 
 ## Protocol Implementations

--- a/threat_model.md
+++ b/threat_model.md
@@ -1054,6 +1054,20 @@ Despite strong encryption, metadata can leak information about users and groups.
   - Gift-wrapping still prevents identification of Welcome vs. other message types
 - **Residual Risk**: Some group size inference possible for sophisticated observers. Mitigation limited until light Welcome objects available.
 
+#### T.11.13 - Live Stream Timing and Size Leakage
+
+- **Description**: Optional [MIP-06](06.md) live streams reveal timing, cadence, duration, and approximate output size beyond the final durable Group Message.
+- **Prerequisites**: Observer can monitor the live transport, relay, or connection metadata.
+- **Impact**: Inference of typing/generation duration, relative message length, and interaction cadence even when final content remains encrypted.
+- **Affected Components**: [MIP-06](06.md) (Ephemeral Live Streams), transport-specific implementations such as QUIC or WebTransport
+- **Countermeasures**:
+  - Treat live frames as optional ephemeral preview state only
+  - Publish the final content as a normal [MIP-03](03.md) Group Message so durable history does not depend on streaming
+  - Use expiry, byte limits, duration limits, and frame-rate limits
+  - Coalesce deltas and optionally pad frames for sensitive contexts
+  - Provide user/application policy to disable live streams
+- **Residual Risk**: Live streaming inherently leaks more timing metadata than a single final message. Users with strong traffic-analysis concerns should disable live streams.
+
 ### 2.12 Cryptographic Attacks
 
 The protocol relies on cryptographic primitives that could be targets for attack.


### PR DESCRIPTION
## Summary
- add optional draft MIP-06 for ephemeral live streams above Marmot/MLS
- define stream offer and final anchor application message kinds
- document MLS exporter-based stream binding while leaving QUIC/WebTransport transport security intact
- add threat-model coverage for live-stream timing and size metadata leakage

## Verification
- git diff --cached --check before commit
- spec/docs only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced MIP-06 specification for an optional Ephemeral Live Streams overlay, defining secure live content delivery with authentication, transport protocols, and receiver verification for Marmot groups.
  * Updated Marmot Implementation Proposals registry to reflect the draft specification.
  * Added metadata leakage and security threat analysis for live stream operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/marmot/pull/70)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->