### PR TITLE
Mark spec as adopted and drop draft/v2 framing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ top-level file stays cross-surface only.
 2. `layout.md`
 3. `principles.md`
 4. The `AGENTS.md` for the surface you are changing (it links its README and the owning docs).
-5. `mip-coverage.md` only when mapping from current MIPs.
+5. `mip-coverage.md` only when mapping from deprecated MIPs.
 6. `implementation-model.md` only when local implementation guidance matters.
 
 ## Rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # AGENTS.md - marmot
 
-Agent map for the Marmot v2 protocol draft.
+Agent map for the Marmot protocol.
 
 ## Scope
 
-This repository is internal draft spec text for protocol surfaces a clean-room implementation would need. The canonical
+This repository is the spec text for protocol surfaces a clean-room implementation would need. The canonical
 directory tree, surface ownership model, and feature/component split live in `layout.md`.
 
 Do not put darkmatter module names, database schemas, queue mechanics, local API shapes, or crate-specific test plans in
@@ -25,7 +25,7 @@ top-level file stays cross-surface only.
 | Optional or user-visible flows that span surfaces | `features/AGENTS.md` |
 | Where new text belongs (canonical tree + ownership) | `layout.md` |
 | How to write the spec (placement + detail rules) | `principles.md` |
-| Map from current MIPs to v2 surfaces | `mip-coverage.md` |
+| Map from deprecated MIPs to this spec's surfaces | `mip-coverage.md` |
 | Non-normative mapping to this repo's code | `implementation-model.md` |
 
 ## Read Order

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Marmot v2 Protocol Draft
+# Marmot Protocol
 
-Status: draft for internal review.
+Status: adopted.
 
-This repository contains the proposed Marmot v2 protocol text. The existing MIP documents remain the current production
-reference until this draft is adopted.
+This repository contains the Marmot protocol text, the version of the protocol ready for adoption. The MIP-era
+documents describe a deprecated version of the protocol.
 
-The draft is organized by protocol surface. Foundation documents define stable Marmot invariants. Protocol-core
+The spec is organized by protocol surface. Foundation documents define stable Marmot invariants. Protocol-core
 documents define how Marmot groups move through MLS flows. Transport documents define how Marmot bytes move over a
 network. App component documents define versioned group-state payloads. Feature documents describe optional or
 user-visible flows and point to the surfaces they touch.
@@ -27,11 +27,9 @@ future transport binding needs the same redundancy and failover properties.
 The protocol also tries to expose as little metadata as the design allows. Perfect metadata privacy is not possible in a
 decentralized messaging system, but Marmot SHOULD avoid new metadata leaks unless a feature cannot work without them.
 
-## Review Status
+## Review Guidance
 
-This is not adopted spec text yet. Treat it as the working v2 draft for team review.
-
-For review, focus on these questions:
+When reviewing changes to the spec, focus on these questions:
 
 - Are rules in the right surface?
 - Are byte encodings exact enough?
@@ -39,11 +37,11 @@ For review, focus on these questions:
 - Are transport-specific rules kept out of foundation and protocol-core docs?
 - Could another implementation build the behavior and write conformance tests from the text?
 
-## Draft Map
+## Spec Map
 
 The canonical directory tree and per-surface ownership rules live in [layout.md](./layout.md). Start there when deciding
 where new protocol text belongs. The writing rules behind that split live in [principles.md](./principles.md). Use
-[mip-coverage.md](./mip-coverage.md) only as a historical map from current MIPs to the v2 surfaces, and
+[mip-coverage.md](./mip-coverage.md) only as a historical map from the deprecated MIPs to this spec's surfaces, and
 [implementation-model.md](./implementation-model.md) for the non-normative mapping to this repository's code.
 
 The surfaces, each with its own section README (human orientation) and `AGENTS.md` (agent operating rules):

--- a/app-components/README.md
+++ b/app-components/README.md
@@ -1,6 +1,6 @@
 # Marmot app components
 
-Status: draft for internal review.
+Status: adopted.
 
 Marmot group state is split into custom MLS app components carried by the MLS `app_data_dictionary` extension. Each
 component has a `ComponentID` and owns the opaque state bytes stored under that id.
@@ -30,7 +30,7 @@ canonical encoding profile. Marmot does not wrap every entry in another generic 
 
 ## Upstream Basis
 
-This draft follows:
+This spec follows:
 
 - [draft-ietf-mls-extensions-09](https://datatracker.ietf.org/doc/html/draft-ietf-mls-extensions-09)
 - [OpenMLS AppData handling](https://book.openmls.tech/user_manual/app_data_updates.html)

--- a/app-components/admin-policy-v1.md
+++ b/app-components/admin-policy-v1.md
@@ -1,6 +1,6 @@
 # marmot.group.admin-policy.v1
 
-Status: draft for internal review.
+Status: adopted.
 
 ## Registry
 

--- a/app-components/agent-text-stream-quic-v1.md
+++ b/app-components/agent-text-stream-quic-v1.md
@@ -1,6 +1,6 @@
 # marmot.group.agent-text-stream.quic.v1
 
-Status: experimental draft for internal review.
+Status: adopted.
 
 ## Registry
 

--- a/app-components/group-avatar-url-v1.md
+++ b/app-components/group-avatar-url-v1.md
@@ -1,6 +1,6 @@
 # marmot.group.avatar-url.v1
 
-Status: draft for internal review.
+Status: adopted.
 
 ## Registry
 
@@ -94,5 +94,5 @@ Removal is equivalent to the empty avatar state for application rendering.
 
 ## Migration
 
-This component is new in v2 and has no MIP-era predecessor. v1 is the first versioned form; a breaking change gets a new
-component id and file.
+This component is new in this spec and has no MIP-era predecessor. v1 is the first versioned form; a breaking change
+gets a new component id and file.

--- a/app-components/group-blossom-image-v1.md
+++ b/app-components/group-blossom-image-v1.md
@@ -1,6 +1,6 @@
 # marmot.group.blossom.image.v1
 
-Status: draft for internal review.
+Status: adopted.
 
 ## Registry
 

--- a/app-components/group-encrypted-media-v1.md
+++ b/app-components/group-encrypted-media-v1.md
@@ -1,6 +1,6 @@
 # marmot.group.encrypted-media.v1
 
-Status: draft for internal review.
+Status: adopted.
 
 ## Registry
 
@@ -111,6 +111,7 @@ media MAY omit it.
 
 ## Migration
 
-This component is new in v2; it carries the Encrypted Media V1 group policy (see [../mip-coverage.md](../mip-coverage.md)).
-The media attachment format and key derivation are owned by [../features/encrypted-media.md](../features/encrypted-media.md).
+This component is new in this spec; it carries the Encrypted Media V1 group policy (see
+[../mip-coverage.md](../mip-coverage.md)). The media attachment format and key derivation are owned by
+[../features/encrypted-media.md](../features/encrypted-media.md).
 v1 is the first versioned form; a breaking change gets a new component id and file.

--- a/app-components/group-profile-v1.md
+++ b/app-components/group-profile-v1.md
@@ -1,6 +1,6 @@
 # marmot.group.profile.v1
 
-Status: draft for internal review.
+Status: adopted.
 
 ## Registry
 

--- a/app-components/message-retention-v1.md
+++ b/app-components/message-retention-v1.md
@@ -1,6 +1,6 @@
 # marmot.group.message-retention.v1
 
-Status: draft for internal review.
+Status: adopted.
 
 ## Registry
 

--- a/app-components/nostr-routing-v1.md
+++ b/app-components/nostr-routing-v1.md
@@ -1,6 +1,6 @@
 # marmot.transport.nostr.routing.v1
 
-Status: draft for internal review.
+Status: adopted.
 
 ## Registry
 

--- a/features/README.md
+++ b/features/README.md
@@ -1,6 +1,6 @@
 # Feature specs
 
-Status: draft for internal review.
+Status: adopted.
 
 Feature specs describe user-visible Marmot behavior that spans several surfaces.
 

--- a/features/agent-text-streams-quic.md
+++ b/features/agent-text-streams-quic.md
@@ -1,6 +1,6 @@
 # Agent text streams over QUIC
 
-Status: experimental draft for internal review.
+Status: adopted.
 
 This feature adds live text previews for agent output in an existing Marmot group. MLS remains the membership,
 authentication, epoch, and durable-message layer. QUIC carries only transient preview records. Live preview delivery is a

--- a/features/encrypted-media.md
+++ b/features/encrypted-media.md
@@ -1,6 +1,6 @@
 # Encrypted Media
 
-Status: draft for internal review.
+Status: adopted.
 
 Encrypted media lets a Marmot app payload refer to one or more encrypted blobs stored outside the MLS message.
 
@@ -21,7 +21,7 @@ Blob upload and download are outside MLS group state. A failed upload or failed 
 The current media format is `encrypted-media-v1`.
 
 New media references MUST use `encrypted-media-v1`. Legacy media version strings are not compatibility formats in this
-draft and MUST be rejected by V1 clients.
+spec and MUST be rejected by V1 clients.
 
 ## Message Shape
 

--- a/features/multi-device.md
+++ b/features/multi-device.md
@@ -1,6 +1,6 @@
 # Multi-device
 
-Status: draft for internal review.
+Status: adopted.
 
 Byte-level definitions in this document are placeholders and not yet finalized. They MUST NOT be implemented for
 interop yet. SHA-256 is the hash function throughout this document; named key derivations use HKDF-SHA256.

--- a/features/push-notifications.md
+++ b/features/push-notifications.md
@@ -1,6 +1,6 @@
 # Push notifications
 
-Status: draft for internal review.
+Status: adopted.
 
 Push notifications let a sender give a recipient a delivery hint outside the normal group-message fetch path.
 
@@ -422,7 +422,7 @@ document changes group state.
 
 The `marmot-push-v1` shapes above are the interop surface: JSON content with explicit member ids, leaf indexes,
 fingerprints, owner-signed token and removal entries, and a kind `446` rumor whose only tag is `v`. Earlier exploratory
-drafts that carried token gossip in `token` tags with empty content, left the sender's leaf implicit, defined no
+versions that carried token gossip in `token` tags with empty content, left the sender's leaf implicit, defined no
 removal entries, or required an `["encoding", "base64"]` tag on the kind `446` rumor are not interoperable with this
 version and predate the owner-authentication and per-record ordering rules; clients MUST reject any `v` other than
 `marmot-push-v1`.

--- a/foundation/README.md
+++ b/foundation/README.md
@@ -1,6 +1,6 @@
 # Marmot foundation
 
-Status: draft for internal review.
+Status: adopted.
 
 These files define the shared choices that make a Marmot implementation a Marmot implementation. Feature docs,
 transport docs, and protocol-core docs SHOULD point here instead of restating these rules.

--- a/foundation/account-identity-proof-v1.md
+++ b/foundation/account-identity-proof-v1.md
@@ -1,6 +1,6 @@
 # Account identity proof v1
 
-Status: draft for internal review.
+Status: adopted.
 
 `marmot.account-identity-proof.v1` is a Marmot custom MLS LeafNode extension that binds the Marmot account identity in
 an MLS `BasicCredential` to that leaf's MLS signature public key.
@@ -87,4 +87,4 @@ A client MUST reject a LeafNode or KeyPackage if:
 - `mls_signature_public_key` does not exactly match the LeafNode MLS signature public key;
 - `schnorr_signature` is not a valid BIP-340 signature for the signing input digest and `account_identity`.
 
-There is no legacy fallback. A member without a valid proof is not a Marmot member for this draft.
+There is no legacy fallback. A member without a valid proof is not a Marmot member under this spec.

--- a/foundation/application-messages.md
+++ b/foundation/application-messages.md
@@ -1,6 +1,6 @@
 # Application payloads
 
-Status: draft for internal review.
+Status: adopted.
 
 Marmot app payloads use a Nostr event shape inside MLS.
 

--- a/foundation/canonical-encoding.md
+++ b/foundation/canonical-encoding.md
@@ -1,6 +1,6 @@
 # Canonical encoding
 
-Status: draft for internal review.
+Status: adopted.
 
 When Marmot signs, hashes, stores, compares, or names protocol values by bytes, those bytes MUST have one encoding.
 

--- a/foundation/errors.md
+++ b/foundation/errors.md
@@ -1,6 +1,6 @@
 # Results and rejections
 
-Status: draft for internal review.
+Status: adopted.
 
 Marmot clients SHOULD be able to describe why an input did not produce application content.
 
@@ -47,8 +47,8 @@ therefore has exactly one outcome: a convergence disposition when it was structu
 otherwise a rejection category.
 
 `delivered` is not a disposition. It names the application-visible output of an `accepted` MLS application message: the
-Marmot app payload handed to the application. `dropped` is not a disposition either; where older drafts said an input
-was dropped, this vocabulary says `stale`.
+Marmot app payload handed to the application. `dropped` is not a disposition either; where older versions of this
+document said an input was dropped, this vocabulary says `stale`.
 
 A disposition says what happened to an input. The categories above say why. A `stale` or `deferred` input SHOULD carry
 a category, such as `duplicate` or `stale_epoch`.

--- a/foundation/host-safety.md
+++ b/foundation/host-safety.md
@@ -1,6 +1,6 @@
 # Host safety
 
-Status: draft for internal review.
+Status: adopted.
 
 Several Marmot surfaces validate a URL whose host a client may reach over the network — encrypted-media `blossom-v1`
 locators, encrypted-media blob endpoints, and the group avatar URL. A fetchable URL pointing at a private, internal, or

--- a/foundation/identity.md
+++ b/foundation/identity.md
@@ -1,6 +1,6 @@
 # Identity, credentials, and capabilities
 
-Status: draft for internal review.
+Status: adopted.
 
 Marmot account identity is a Nostr public key.
 

--- a/foundation/key-packages.md
+++ b/foundation/key-packages.md
@@ -1,6 +1,6 @@
 # KeyPackages
 
-Status: draft for internal review.
+Status: adopted.
 
 This document defines KeyPackage meaning, discovery requirements, and lifecycle.
 

--- a/foundation/mls-protocol.md
+++ b/foundation/mls-protocol.md
@@ -1,6 +1,6 @@
 # MLS protocol
 
-Status: draft for internal review.
+Status: adopted.
 
 Marmot currently uses MLS as its continuous group key agreement (CGKA) protocol.
 
@@ -83,5 +83,5 @@ Registered Marmot exporter labels are listed in [registries.md](./registries.md)
 
 ## Exporter research
 
-Before this draft becomes normative, research whether the MLS Extensions Safe framework's exporter APIs are useful for
-any Marmot secret derivation. This draft does not assign one.
+Research whether the MLS Extensions Safe framework's exporter APIs are useful for
+any Marmot secret derivation. This spec does not assign one.

--- a/foundation/registries.md
+++ b/foundation/registries.md
@@ -1,6 +1,6 @@
 # Registries
 
-Status: draft for internal review.
+Status: adopted.
 
 This file collects Marmot-owned ids so new documents do not accidentally reuse a value.
 
@@ -70,7 +70,7 @@ confirm the values when that feature lands. `0xf2f1` is implemented and required
 
 ## Marmot custom proposal types
 
-No Marmot-owned custom MLS proposal type is assigned in this draft yet.
+No Marmot-owned custom MLS proposal type is assigned in this spec yet.
 
 `IdentityRemove` is the first likely candidate. It MUST claim a proposal type here before becoming normative.
 

--- a/foundation/wire-envelopes.md
+++ b/foundation/wire-envelopes.md
@@ -1,6 +1,6 @@
 # Wire envelopes
 
-Status: draft for internal review.
+Status: adopted.
 
 Marmot separates application payloads, MLS security bytes, and transport delivery.
 

--- a/layout.md
+++ b/layout.md
@@ -1,9 +1,9 @@
 # Spec layout
 
-Status: draft for internal review.
+Status: adopted.
 
-The current MIP set mixes stable protocol surfaces with feature behavior. The
-v2 draft organizes docs around the surface an implementer is building.
+The deprecated MIP set mixes stable protocol surfaces with feature behavior. This
+spec organizes docs around the surface an implementer is building.
 
 MIPs remain useful history. They SHOULD point to the stable docs they changed.
 
@@ -147,7 +147,7 @@ local APIs, queues, storage choices, and diagnostics.
 
 ## MIP Coverage
 
-The v2 draft keeps MIP history separate from normative organization.
+This spec keeps MIP history separate from normative organization.
 
-Use [mip-coverage.md](./mip-coverage.md) to see where current MIP-era concerns moved. The stable spec SHOULD be readable
+Use [mip-coverage.md](./mip-coverage.md) to see where MIP-era concerns moved. The stable spec SHOULD be readable
 without replaying the MIP history.

--- a/mip-coverage.md
+++ b/mip-coverage.md
@@ -1,18 +1,18 @@
 # MIP coverage
 
-Status: draft for internal review.
+Status: adopted.
 
-This file maps the current Marmot MIPs to the v2 draft. It is a review aid, not a normative surface.
+This file maps the deprecated Marmot MIPs to this spec. It is a review aid, not a normative surface.
 
 The merged canonical MIP set currently lives on the old Marmot repo's `origin/master`. MIP-06 exists as branch draft
-work and is tracked here because it affects the likely v2 design.
+work and is tracked here because it affects this spec's design.
 
-## Current MIPs
+## Deprecated MIPs
 
 - MIP-00, Credentials & Key Packages: Review and required.
   - Foundation: [foundation/identity.md](./foundation/identity.md) and
     [foundation/key-packages.md](./foundation/key-packages.md);
-    [foundation/account-identity-proof-v1.md](./foundation/account-identity-proof-v1.md) is new in v2 and breaking
+    [foundation/account-identity-proof-v1.md](./foundation/account-identity-proof-v1.md) is new in this spec and breaking
   - Transport binding: [transports/nostr.md](./transports/nostr.md)
   - Protocol flow: [protocol-core/joining.md](./protocol-core/joining.md)
 - MIP-01, Group Construction & Marmot Group Data Extension: Review and required.
@@ -39,10 +39,10 @@ work and is tracked here because it affects the likely v2 design.
 
 ## MIP-01 field split
 
-MIP-01 used one monolithic MLS extension, `marmot_group_data`. The v2 draft keeps the same semantics but splits that
+MIP-01 used one monolithic MLS extension, `marmot_group_data`. This spec keeps the same semantics but splits that
 state into smaller app components.
 
-| MIP-era field               | v2 owner                            |
+| MIP-era field               | Owner in this spec                  |
 | --------------------------- | ----------------------------------- |
 | `name`                      | `marmot.group.profile.v1`           |
 | `description`               | `marmot.group.profile.v1`           |
@@ -55,7 +55,7 @@ state into smaller app components.
 | `image_upload_key`          | `marmot.group.blossom.image.v1`     |
 | `disappearing_message_secs` | `marmot.group.message-retention.v1` |
 
-The component docs own the exact v2 bytes. This table only records where the old fields went.
+The component docs own the exact bytes. This table only records where the old fields went.
 
 ## Transport-specific MIP details
 

--- a/principles.md
+++ b/principles.md
@@ -1,8 +1,8 @@
 # Principles for writing Marmot specs
 
-Status: draft for internal review.
+Status: adopted.
 
-These principles are for the Marmot v2 draft. They explain how we decide where rules belong and how much detail a spec
+These principles are for the Marmot spec. They explain how we decide where rules belong and how much detail a spec
 document needs before another implementation could build from it.
 
 They are intentionally more prescriptive than style notes. When a principle starts defining exact client behavior, move

--- a/protocol-core/README.md
+++ b/protocol-core/README.md
@@ -1,6 +1,6 @@
 # Protocol core
 
-Status: draft for internal review.
+Status: adopted.
 
 Protocol core describes what Marmot clients do with MLS group state.
 

--- a/protocol-core/convergence.md
+++ b/protocol-core/convergence.md
@@ -1,6 +1,6 @@
 # Convergence
 
-Status: draft for internal review.
+Status: adopted.
 
 Convergence chooses one canonical branch from unordered group input.
 

--- a/protocol-core/group-messaging.md
+++ b/protocol-core/group-messaging.md
@@ -1,6 +1,6 @@
 # Group messaging
 
-Status: draft for internal review.
+Status: adopted.
 
 This document describes group control messages and encrypted app payloads.
 
@@ -83,6 +83,6 @@ replaces retention data so the on-wire behavior is determined by group state.
 
 ## Migration notes
 
-This document is the v2 home for MIP-03 group-message behavior; the [MIP coverage map](../mip-coverage.md) records where
-each MIP-03 concern moved. As with the whole draft, the merged MIP set stays the production reference until v2 is
-adopted (see the [spec README](../README.md)).
+This document is the home for MIP-03 group-message behavior; the [MIP coverage map](../mip-coverage.md) records where
+each MIP-03 concern moved. The MIP-era documents are a deprecated version of the protocol (see the
+[spec README](../README.md)).

--- a/protocol-core/group-setup.md
+++ b/protocol-core/group-setup.md
@@ -1,6 +1,6 @@
 # Group construction and settings
 
-Status: draft for internal review.
+Status: adopted.
 
 This document describes group creation and the signed settings every member MUST agree on.
 

--- a/protocol-core/group-state.md
+++ b/protocol-core/group-state.md
@@ -1,6 +1,6 @@
 # Group state
 
-Status: draft for internal review.
+Status: adopted.
 
 Each Marmot group has one canonical MLS state at a time. A client MAY temporarily hold candidate or pending state, but
 only one state is visible as the group's canonical state.

--- a/protocol-core/inbound-processing.md
+++ b/protocol-core/inbound-processing.md
@@ -1,6 +1,6 @@
 # Inbound processing
 
-Status: draft for internal review.
+Status: adopted.
 
 Inbound processing accepts bytes from a transport, turns them into Marmot protocol input, and gives each input a
 disposition.

--- a/protocol-core/joining.md
+++ b/protocol-core/joining.md
@@ -1,6 +1,6 @@
 # Welcomes
 
-Status: draft for internal review.
+Status: adopted.
 
 This document describes the member join flow built around MLS Welcomes.
 
@@ -58,7 +58,7 @@ After unwrapping a Welcome, the receiver:
 13. performs a self-update as soon as practical.
 
 A new member SHOULD perform the post-join self-update before sending application payloads when feasible, and SHOULD do
-so promptly after joining. This carries forward the MIP-02 post-join rotation guidance; the v2 draft keeps it as a
+so promptly after joining. This carries forward the MIP-02 post-join rotation guidance; this spec keeps it as a
 `SHOULD` because a member who never rotates is a forward-secrecy weakness for itself, not a correctness break for the
 group. The concrete recommended completion window is operational, not interop-visible, so it lives in
 [../implementation-model.md](../implementation-model.md) rather than here.

--- a/protocol-core/member-departure.md
+++ b/protocol-core/member-departure.md
@@ -1,6 +1,6 @@
 # Member departure
 
-Status: draft for internal review.
+Status: adopted.
 
 Member departure covers two paths: a member leaving on its own through SelfRemove, and an admin removing another
 member. This document specifies the SelfRemove path in full. Ordinary admin-initiated removal is an admin-gated
@@ -86,5 +86,5 @@ A SelfRemove flow is invalid if:
 
 ## Migration notes
 
-MIP-era Marmot treated SelfRemove as part of group messaging behavior. In the v2 draft it lives in protocol core because
+MIP-era Marmot treated SelfRemove as part of group messaging behavior. In this spec it lives in protocol core because
 SelfRemove affects the required group-state flow.

--- a/protocol-core/publish-lifecycle.md
+++ b/protocol-core/publish-lifecycle.md
@@ -1,6 +1,6 @@
 # Publish lifecycle
 
-Status: draft for internal review.
+Status: adopted.
 
 This document states the publish-before-apply rule for locally generated group-state changes.
 

--- a/protocol-core/retained-history.md
+++ b/protocol-core/retained-history.md
@@ -1,6 +1,6 @@
 # Retained history
 
-Status: draft for internal review.
+Status: adopted.
 
 Marmot clients need retained group state so they can recover from forks and late delivery.
 

--- a/transports/README.md
+++ b/transports/README.md
@@ -1,6 +1,6 @@
 # Transport specs
 
-Status: draft for internal review.
+Status: adopted.
 
 Transport specs describe how a network carries Marmot MLS bytes.
 

--- a/transports/nostr.md
+++ b/transports/nostr.md
@@ -1,6 +1,6 @@
 # Nostr transport
 
-Status: draft for internal review.
+Status: adopted.
 
 This document defines the first Marmot transport binding: MLS bytes carried over Nostr relays.
 

--- a/transports/quic.md
+++ b/transports/quic.md
@@ -1,6 +1,6 @@
 # Raw QUIC transport (agent text stream previews)
 
-Status: experimental draft for internal review.
+Status: adopted.
 
 This document defines the raw QUIC transport binding for live agent text stream previews. It is the transport companion
 to the feature document [../features/agent-text-streams-quic.md](../features/agent-text-streams-quic.md): the feature


### PR DESCRIPTION
## What changed

- All `Status: draft for internal review.` (and `experimental draft`) lines — 42 files — now read `Status: adopted.`. `implementation-model.md` keeps its `non-normative draft for internal review` status intentionally.
- README/AGENTS framing rewritten: the repository is now presented as the Marmot protocol text ready for adoption, and the MIP-era documents are described as a deprecated version of the protocol. The README's "Review Status" section ("This is not adopted spec text yet") became "Review Guidance" for reviewing changes to the spec, and "Draft Map" became "Spec Map".
- The spec-version "v2" label is removed throughout: the README title is now "Marmot Protocol", and MIP-contrast sentences ("new in v2", "the v2 spec keeps...", the `v2 owner` table column in mip-coverage.md) use "this spec" phrasing instead.
- Assorted "in this draft" phrasings became "in this spec" / "under this spec", and two migration paragraphs were rewrapped to the ~120-char convention.

## Intentionally unchanged

- IETF references (`draft-ietf-mls-extensions-09`, "the MLS extensions draft").
- MIP draft statuses in `mip-coverage.md` (MIP-05, MIP-06).
- The multi-device feature's own draft language (`features/multi-device.md`) — the feature itself is still a draft, though its status line now says adopted like every other doc; flag in review if it should carry a different status.
- The component-version "a breaking v2 gets a new component id/file" bullets in `app-components/README.md`.

## Reviewer notes

The repo's `AGENTS.md` verification greps come back clean: remaining matches are only the intentional ones in `implementation-model.md`, the AGENTS boundary docs, and two pre-existing "relay hints" lines in `features/push-notifications.md` untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/marmot/pull/170">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Marmot docs to present the protocol and component specs as **adopted** and ready for use.
  * Refreshed wording throughout to replace “draft”/“v2” references with “spec”/“this spec.”
  * Improved documentation navigation by updating review guidance, spec maps, and reading order to better reflect historical vs. current surfaces.
  * Clarified multiple status, migration, and compatibility notes (including terminology such as “stale” vs. older vocabulary).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->