### PR TITLE
Align admin-policy, membership, and role-change invariants

### DIFF
--- a/app-components/admin-policy-v1.md
+++ b/app-components/admin-policy-v1.md
@@ -67,6 +67,12 @@ The last check is cross-component: it validates this component against the resul
 against the component bytes alone. Commit validity already spans components, so a commit whose resulting epoch lists an
 admin key with no member leaf is invalid.
 
+The cross-component check is a property of the resulting epoch, not of the commits that carry admin-policy bytes. It
+runs on every commit that changes the member leaf set or this component's state. When a commit carries no admin-policy
+update, the resulting epoch's admin set is the prior epoch's admin set carried forward, and the check is evaluated
+against that carried-forward set. A commit that removes a listed account's last member leaf without also updating this
+component is therefore invalid whether or not the commit re-serializes this component's bytes.
+
 ## Authorization
 
 Only an active admin MAY send a standalone admin policy proposal.

--- a/foundation/errors.md
+++ b/foundation/errors.md
@@ -61,11 +61,15 @@ Protocol-core documents name some outcomes in `PascalCase`. Each maps to one dis
 | ----------------------- | ----------- | ----------------- | ----------------------------------------------------------- |
 | `BeyondAnchor`          | `stale`     | `stale_epoch`     | [retained-history.md](../protocol-core/retained-history.md) |
 | `MissingRetainedAnchor` | `deferred`  | `missing_history` | [retained-history.md](../protocol-core/retained-history.md) |
+| `SelfEvicted`           | `stale`     | `stale_epoch`     | [member-departure.md](../protocol-core/member-departure.md) |
 
 `BeyondAnchor` is window exclusion by design: the source epoch is older than the retained anchor, and the input will
 never be processed. `MissingRetainedAnchor` is storage loss: required retained state inside the rollback horizon is
 gone, canonical group state does not change, and the group moves to `Unrecoverable` (a group lifecycle state, not a
-disposition) until a verified repair path exists; the input stays deferred rather than terminal.
+disposition) until a verified repair path exists; the input stays deferred rather than terminal. `SelfEvicted` is
+terminal for the group on that client: the input is from an epoch past the local member's own removal, and the required
+side effect — realizing the removal — is defined in
+[member-departure.md](../protocol-core/member-departure.md) ("Realizing removal").
 
 ## Protocol and local errors
 

--- a/foundation/errors.md
+++ b/foundation/errors.md
@@ -67,8 +67,8 @@ Protocol-core documents name some outcomes in `PascalCase`. Each maps to one dis
 never be processed. `MissingRetainedAnchor` is storage loss: required retained state inside the rollback horizon is
 gone, canonical group state does not change, and the group moves to `Unrecoverable` (a group lifecycle state, not a
 disposition) until a verified repair path exists; the input stays deferred rather than terminal. `SelfEvicted` is
-terminal for the group on that client: the input is from an epoch past the local member's own removal, and the required
-side effect — realizing the removal — is defined in
+terminal for the group on that client: it attaches to later input for a group whose retained canonical state records
+the local member's own removal, and the required side effect — realizing the removal — is defined in
 [member-departure.md](../protocol-core/member-departure.md) ("Realizing removal").
 
 ## Protocol and local errors

--- a/protocol-core/convergence.md
+++ b/protocol-core/convergence.md
@@ -57,8 +57,13 @@ Until such a component exists, there is no mechanism to change the active policy
 
 A client builds candidate branches by replaying MLS commit bytes from retained group states.
 
-A commit creates a candidate edge only when it validates against exactly one parent state. A commit whose parent is not
-available remains deferred until the parent appears or the input expires.
+A commit creates a candidate edge only when it validates against exactly one parent state. Validation here is full
+commit validity: MLS validation plus Marmot component validation, including cross-component resulting-epoch checks such
+as the admin/leaf coupling in [../app-components/admin-policy-v1.md](../app-components/admin-policy-v1.md)
+("Validation"). A commit whose resulting state fails those checks is invalid on every branch and MUST NOT create a
+candidate edge, so convergence can never select a branch that contains it.
+
+A commit whose parent is not available remains deferred until the parent appears or the input expires.
 
 A client MUST NOT trust transport-provided parent metadata when building a branch. Parentage is derived by replaying MLS
 bytes against retained candidate states.
@@ -208,6 +213,12 @@ The client then assigns dispositions (the disposition vocabulary is pinned in
 Applying the selected branch also produces application-visible state notifications for changes the application MAY need
 to render or act on. Examples include epoch advancement, member additions, member removals, app component changes,
 branch recovery, and app payload invalidation.
+
+State notifications are derived only from accepted commits on the selected branch and the canonical resulting state
+they produce. When branch selection supersedes a commit the client previously applied — including the client's own
+published and confirmed commit — state notifications derived from that commit MUST be withdrawn from application
+output, symmetric with app-payload invalidation. A group-state change that lost branch selection MUST NOT remain
+visible to the application as a completed change.
 
 If the required retained state is missing, the client MUST report the missing retained anchor and MUST NOT mutate
 canonical group state. If the missing state is inside the rollback horizon, the client enters `Unrecoverable` until it

--- a/protocol-core/convergence.md
+++ b/protocol-core/convergence.md
@@ -215,10 +215,17 @@ to render or act on. Examples include epoch advancement, member additions, membe
 branch recovery, and app payload invalidation.
 
 State notifications are derived only from accepted commits on the selected branch and the canonical resulting state
-they produce. When branch selection supersedes a commit the client previously applied — including the client's own
-published and confirmed commit — state notifications derived from that commit MUST be withdrawn from application
-output, symmetric with app-payload invalidation. A group-state change that lost branch selection MUST NOT remain
-visible to the application as a completed change.
+they produce. A state notification derived from a commit is attributed to that commit's `commit_digest` (the same
+`SHA-256` over the commit's MLS bytes defined in "Same-epoch races"). When branch selection supersedes a commit the
+client previously applied — including the client's own published and confirmed commit — the client MUST emit a
+group-state-change invalidation naming the superseded commit, and every state notification attributed to that commit
+is withdrawn: the application treats the changes it announced as not having happened. This is the state-notification
+counterpart of app-payload invalidation.
+
+Notification objects are local API surface, so their exact shape is implementation-defined; the conformance
+requirement is the resulting view. Once convergence is settled, the state notifications still in effect are exactly
+those derivable from the accepted commits on the selected branch, and a group-state change that lost branch selection
+MUST NOT remain visible to the application as a completed change.
 
 If the required retained state is missing, the client MUST report the missing retained anchor and MUST NOT mutate
 canonical group state. If the missing state is inside the rollback horizon, the client enters `Unrecoverable` until it

--- a/protocol-core/group-state.md
+++ b/protocol-core/group-state.md
@@ -28,6 +28,10 @@ A member that has sent a SelfRemove proposal also enters the local `Leaving` gat
 still contains the member until a commit removes it. It is a durable outbound restriction on the leaving client and may
 span multiple epoch-bound SelfRemove proposals.
 
+A member whose own removal has been realized holds the group as a removed, inactive copy per
+[member-departure.md](./member-departure.md) ("Realizing removal"). Like `Leaving`, this is not a canonical lifecycle
+state; it is a terminal local condition for that group copy.
+
 ## Legal transitions
 
 ```text

--- a/protocol-core/inbound-processing.md
+++ b/protocol-core/inbound-processing.md
@@ -77,7 +77,11 @@ Input that cannot affect the group MUST receive a stale disposition. This includ
   `app_payload_past_epoch_limit` past epochs, see [convergence.md](./convergence.md));
 - commits that fork from outside the rollback horizon: these are ineligible for branch selection (see
   [convergence.md](./convergence.md), "Eligibility") and, when their source epoch is also older than the retained
-  anchor, are reported as `BeyondAnchor`.
+  anchor, are reported as `BeyondAnchor`;
+- group input past the local member's own removal (`SelfEvicted` -> `stale_epoch`, per
+  [member-departure.md](./member-departure.md), "Realizing removal"): stale for convergence, but when it is the
+  client's first authenticated evidence of its own removal, the client MUST also surface that removal as a state
+  notification instead of failing silently.
 
 The `snake_case` names in parentheses are the shared categories in [../foundation/errors.md](../foundation/errors.md);
 `BeyondAnchor` is a named convergence outcome that maps to the `stale` disposition and the `stale_epoch` category.
@@ -95,12 +99,18 @@ State notifications include events such as:
 
 - group joined;
 - epoch advanced;
-- member added or removed;
+- member added or removed, including the local member's own removal (see
+  [member-departure.md](./member-departure.md), "Realizing removal");
 - component state changed;
 - branch recovered;
 - app payload invalidated because its MLS application message belonged only to a losing branch.
 
 A state notification is not a delivered app payload. It tells the application what changed in the group state.
+
+State notifications track the selected canonical branch. When convergence supersedes a commit the client previously
+applied, state notifications derived from that commit MUST be withdrawn from application output (see
+[convergence.md](./convergence.md), "Applying the selected branch"), so the application never keeps rendering a
+group-state change that the canonical state contradicts.
 
 ## Delivered app payloads
 

--- a/protocol-core/inbound-processing.md
+++ b/protocol-core/inbound-processing.md
@@ -78,10 +78,10 @@ Input that cannot affect the group MUST receive a stale disposition. This includ
 - commits that fork from outside the rollback horizon: these are ineligible for branch selection (see
   [convergence.md](./convergence.md), "Eligibility") and, when their source epoch is also older than the retained
   anchor, are reported as `BeyondAnchor`;
-- group input past the local member's own removal (`SelfEvicted` -> `stale_epoch`, per
-  [member-departure.md](./member-departure.md), "Realizing removal"): stale for convergence, but when it is the
-  client's first authenticated evidence of its own removal, the client MUST also surface that removal as a state
-  notification instead of failing silently.
+- group input for a group whose retained canonical state records the local member's own removal (`SelfEvicted` ->
+  `stale_epoch`, per [member-departure.md](./member-departure.md), "Realizing removal"): stale for convergence, but
+  processing it MUST also surface the member's removal as a state notification when the application has not yet
+  observed it, instead of failing silently.
 
 The `snake_case` names in parentheses are the shared categories in [../foundation/errors.md](../foundation/errors.md);
 `BeyondAnchor` is a named convergence outcome that maps to the `stale` disposition and the `stale_epoch` category.
@@ -103,14 +103,15 @@ State notifications include events such as:
   [member-departure.md](./member-departure.md), "Realizing removal");
 - component state changed;
 - branch recovered;
-- app payload invalidated because its MLS application message belonged only to a losing branch.
+- app payload invalidated because its MLS application message belonged only to a losing branch;
+- group-state change invalidated because the commit it was derived from was superseded by branch selection.
 
 A state notification is not a delivered app payload. It tells the application what changed in the group state.
 
 State notifications track the selected canonical branch. When convergence supersedes a commit the client previously
-applied, state notifications derived from that commit MUST be withdrawn from application output (see
-[convergence.md](./convergence.md), "Applying the selected branch"), so the application never keeps rendering a
-group-state change that the canonical state contradicts.
+applied, the client MUST emit a group-state-change invalidation naming the superseded commit, and state notifications
+attributed to that commit are withdrawn from application output (see [convergence.md](./convergence.md), "Applying the
+selected branch"), so the application never keeps rendering a group-state change that the canonical state contradicts.
 
 ## Delivered app payloads
 

--- a/protocol-core/member-departure.md
+++ b/protocol-core/member-departure.md
@@ -6,7 +6,8 @@ Member departure covers two paths: a member leaving on its own through SelfRemov
 member. This document specifies the SelfRemove path in full. Ordinary admin-initiated removal is an admin-gated
 group-state change whose authorization is owned by
 [../app-components/admin-policy-v1.md](../app-components/admin-policy-v1.md) ("remove another member"); it otherwise
-follows the normal commit, publish-lifecycle, and convergence rules.
+follows the normal commit, publish-lifecycle, and convergence rules. Both paths end with the removed member realizing
+its own removal; that flow is "Realizing removal" below.
 
 SelfRemove lets a current member leave a group without asking an admin to remove them. It uses the MLS SelfRemove
 proposal from the MLS extensions work and does not define a Marmot custom proposal type.
@@ -72,6 +73,40 @@ A client that receives multiple SelfRemove proposals from the same leaving membe
 is consumed MUST bound storage and commit eligibility to one retained proposal. Byte-identical repeats are duplicates
 under [inbound-processing.md](./inbound-processing.md), and non-identical redundant proposals are stale unless a future
 protocol version defines a distinct retry identity.
+
+## Realizing removal
+
+Both departure paths end the same way for the removed member: its client realizes that its membership ended, tells the
+application, and stops treating the group as active. Realization has a primary input and a fallback input.
+
+The primary input is the removing commit. When an accepted commit on the selected canonical branch removes the local
+member's last leaf — an admin-initiated Remove or a committed SelfRemove — the client MUST emit a self-removed state
+notification (see [inbound-processing.md](./inbound-processing.md), "Application-visible output") and mark the local
+group copy removed.
+
+The fallback input covers a client that never applied the removing commit. If processing later group input yields
+authenticated evidence that the local member's membership already ended — the local group state records the member's
+own removal while the client is still presenting the group as active — the client MUST treat that evidence as
+realization of its own removal: the same self-removed state notification and the same removed group condition. The
+triggering input receives the `SelfEvicted` outcome (`stale` disposition, `stale_epoch` category, see
+[../foundation/errors.md](../foundation/errors.md)). The client MUST NOT report such input as ordinary stale traffic
+and keep presenting the group as active.
+
+Failure to decrypt group traffic is not, by itself, evidence of removal. Without authenticated evidence that the local
+member's own leaf was removed, undecryptable input is a missing-history or repair condition (see
+[retained-history.md](./retained-history.md) and [group-state.md](./group-state.md), "Unrecoverable cases"), and the
+client MUST NOT present the group as removed.
+
+A removed group copy is retained inactive, not deleted. The removed member:
+
+- MUST NOT prepare or publish commits, proposals, or MLS application messages for the group;
+- MUST NOT present the group to the user as active or sendable;
+- MAY retain previously delivered content and group history for local display;
+- MAY discard the local group copy at any time.
+
+Removal is terminal for that group copy. Rejoining happens only through a new Welcome, which creates a new local group
+state under [joining.md](./joining.md). Retention does not weaken forward secrecy: a removed member cannot decrypt
+traffic from epochs after its removal.
 
 ## Validation
 

--- a/protocol-core/member-departure.md
+++ b/protocol-core/member-departure.md
@@ -77,20 +77,25 @@ protocol version defines a distinct retry identity.
 ## Realizing removal
 
 Both departure paths end the same way for the removed member: its client realizes that its membership ended, tells the
-application, and stops treating the group as active. Realization has a primary input and a fallback input.
+application, and stops treating the group as active.
 
-The primary input is the removing commit. When an accepted commit on the selected canonical branch removes the local
-member's last leaf — an admin-initiated Remove or a committed SelfRemove — the client MUST emit a self-removed state
-notification (see [inbound-processing.md](./inbound-processing.md), "Application-visible output") and mark the local
-group copy removed.
+The authenticated evidence of removal is always the same bytes: an accepted commit on the selected canonical branch
+that removes the local member's last leaf — an admin-initiated Remove or a committed SelfRemove — recorded in retained
+canonical state. When the client applies such a commit, it MUST emit a self-removed state notification (see
+[inbound-processing.md](./inbound-processing.md), "Application-visible output") and mark the local group copy removed.
 
-The fallback input covers a client that never applied the removing commit. If processing later group input yields
-authenticated evidence that the local member's membership already ended — the local group state records the member's
-own removal while the client is still presenting the group as active — the client MUST treat that evidence as
-realization of its own removal: the same self-removed state notification and the same removed group condition. The
-triggering input receives the `SelfEvicted` outcome (`stale` disposition, `stale_epoch` category, see
-[../foundation/errors.md](../foundation/errors.md)). The client MUST NOT report such input as ordinary stale traffic
-and keep presenting the group as active.
+Realization is a state-derived obligation, not a one-shot event at commit-apply time: whenever retained canonical group
+state records the local member's removal and the local group copy is not yet marked removed, the client MUST perform
+the realization above. A client MAY have recorded the removing commit without the application ever observing the
+resulting notification; the obligation stands until the group copy is marked removed.
+
+Later group input for such a group is the fallback trigger. It receives the `SelfEvicted` outcome (`stale`
+disposition, `stale_epoch` category, see [../foundation/errors.md](../foundation/errors.md)). `SelfEvicted` attaches
+to that later input, not to the removing commit and not to a local presentation mismatch; the input itself proves
+nothing and need not be decrypted or authenticated, because the evidence of removal is the retained canonical state —
+the input is classified by its group, like other stale input for groups the client cannot process further. Processing
+it MUST perform the realization above when it has not already happened. The client MUST NOT classify such input as
+ordinary stale traffic while continuing to present the group as active.
 
 Failure to decrypt group traffic is not, by itself, evidence of removal. Without authenticated evidence that the local
 member's own leaf was removed, undecryptable input is a missing-history or repair condition (see


### PR DESCRIPTION
## Summary

Spec-side changes for [#79](https://github.com/marmot-protocol/marmot/issues/79) ("Align admin-policy, membership, and role-change invariants"). The producing-side remove bug (marmot-protocol/mdk#362) is already covered by existing spec text (`admin-policy-v1.md`, coupling rule); this PR closes the four remaining spec gaps behind the other child issues.

## Changes

**1. Pin *when* the admin/leaf coupling check runs** — `app-components/admin-policy-v1.md` (addresses marmot-protocol/mdk#393)

The cross-component check is now stated as a property of every resulting epoch: it runs on any commit that changes the member leaf set or the admin-policy component, and when the commit carries no admin-policy update it is evaluated against the prior epoch's admin set carried forward. A Remove that orphans an admin is invalid even when the commit does not re-serialize the admin-policy bytes.

**2. Branch replay validates cross-component checks** — `protocol-core/convergence.md` "Candidate branches" (normativizes marmot-protocol/darkmatter#578's projection-side rejection)

"Validates" for candidate edges now explicitly means full commit validity: MLS validation plus Marmot component validation including cross-component resulting-epoch checks. An invariant-violating commit cannot create a candidate edge on any branch, so convergence can never select a branch containing one.

**3. State notifications are withdrawn on losing branches** — `protocol-core/convergence.md` "Applying the selected branch" and `protocol-core/inbound-processing.md` "Application-visible output" (addresses marmot-protocol/mdk#363)

State notifications derive only from accepted commits on the selected branch. When branch selection supersedes a previously applied commit — including the client's own published and confirmed commit — notifications derived from it MUST be withdrawn, symmetric with app-payload invalidation. This is the spec-level fix behind the "losing rename renders as a successful system message" bug.

**4. Removed-member realization flow, retain-inactive** — new "Realizing removal" section in `protocol-core/member-departure.md`, plus `inbound-processing.md`, `foundation/errors.md`, and `group-state.md` (addresses marmot-protocol/mdk#376)

The old `data_flows.md` mandate ("Process Commit, Realize removed, Delete group state") was dropped in the v2 rewrite; the removed member's own side of removal was specified nowhere. The new section defines:

- the primary realization input: an accepted canonical commit removing the local member's last leaf → self-removed state notification, group copy marked removed;
- the fallback input for a client that never applied the removing commit: authenticated post-eviction evidence MUST surface the same self-removal instead of being reported as generic stale traffic (the silent-eviction gap), with a new `SelfEvicted` named outcome (`stale` / `stale_epoch`) registered in `errors.md`;
- an explicit guard that undecryptable traffic alone is *not* removal evidence — that is a missing-history/repair condition;
- retain-inactive semantics: the removed copy is kept, not deleted — no sending, not presented as active, history MAY be retained for display, rejoin only via a new Welcome.

`group-state.md` gets a cross-reference placing the removed condition next to the `Leaving` gate it parallels (a local terminal condition, not a canonical lifecycle state).

## Reviewer notes

- The `SelfEvicted` name was chosen to match the existing PascalCase outcomes (`BeyondAnchor`, `MissingRetainedAnchor`); easy to rename.
- The AGENTS.md verification greps were run after editing; the only matches are the intentional ones in `implementation-model.md` and the AGENTS files themselves.
- Refs #79. Spec-side counterparts to marmot-protocol/mdk#362, marmot-protocol/mdk#363, marmot-protocol/mdk#376, marmot-protocol/mdk#393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/marmot/pull/171">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer handling for member removal, including a defined “realizing removal” state and a self-removal notification.
  * Application-visible state updates now follow the canonical selected branch, with superseded updates withdrawn if convergence changes.

* **Bug Fixes**
  * Stale input is now handled more explicitly when it arrives after a member’s own removal.
  * Clarified that removal-related updates are validated against the resulting state, even across commit changes.

* **Documentation**
  * Expanded protocol notes to better explain convergence, branch selection, and terminal group-copy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->