### PR TITLE
Tighten wire-boundary validation rules

### DIFF
--- a/foundation/canonical-encoding.md
+++ b/foundation/canonical-encoding.md
@@ -41,6 +41,17 @@ concatenated encoded items. The maximum byte length is `2^62 - 1`. A decoder MUS
 body decodes to a whole number of items with no trailing bytes. Owning documents SHOULD give a tighter bound when one
 applies. An unbounded `<V>` means only the QUIC variable-length integer maximum applies.
 
+## Tuple and preimage boundaries
+
+When a Marmot-owned value combines more than one field into bytes for signing, hashing, key derivation, replay storage,
+comparison, or naming, every field boundary MUST be unambiguous. A variable-length field MUST be encoded with an
+explicit length prefix, carried inside an upstream canonical encoding that already preserves its boundary, or be
+separated by an owning-document rule that cannot collide with any legal value.
+
+A producer MUST NOT create a collision-prone preimage by bare-concatenating adjacent variable-length fields. A domain
+separator, text label, or version suffix is useful for separating one construction from another, but it does not by
+itself mark the boundary between two variable-length fields inside the same construction.
+
 ## QUIC length prefixes
 
 A QUIC variable-length integer length prefix uses the two high bits of the first byte to say how many bytes encode the

--- a/foundation/key-packages.md
+++ b/foundation/key-packages.md
@@ -69,6 +69,11 @@ active transport binding. Candidate freshness is only a KeyPackage selection inp
 MUST NOT override decoded KeyPackage validity, account identity proof validity, capability compatibility, or transport
 author binding.
 
+The MLS `Lifetime` extension is part of KeyPackage validity. A Marmot KeyPackage candidate MUST carry a `Lifetime`
+extension, MUST be current at validation time (`not_before < now < not_after`), and MUST have
+`not_after - not_before <= 7,261,200` seconds. The range is 84 days plus a one-hour clock-skew margin. A `last_resort`
+KeyPackage does not relax this limit.
+
 When a transport exposes a publication timestamp or replacement rule, clients SHOULD use it to avoid consuming stale
 single-use KeyPackages. If two otherwise equivalent candidates remain, clients SHOULD use a deterministic
 content-derived tie-breaker defined by the transport binding.
@@ -88,6 +93,8 @@ available so the inviter can retry or choose another candidate.
 A client MUST reject a published KeyPackage when:
 
 - the decoded content is not a valid MLS KeyPackage;
+- the KeyPackage `Lifetime` extension is missing, expired, not yet valid, or has a total range longer than
+  7,261,200 seconds;
 - the credential identity is not a valid Marmot account identity;
 - the account identity proof extension is missing or invalid;
 - the transport author or sender does not match the credential identity under the active transport binding;

--- a/foundation/key-packages.md
+++ b/foundation/key-packages.md
@@ -70,9 +70,9 @@ MUST NOT override decoded KeyPackage validity, account identity proof validity, 
 author binding.
 
 The MLS `Lifetime` extension is part of KeyPackage validity. A Marmot KeyPackage candidate MUST carry a `Lifetime`
-extension, MUST be current at validation time (`not_before < now < not_after`), and MUST have
-`not_after - not_before <= 7,261,200` seconds. The range is 84 days plus a one-hour clock-skew margin. A `last_resort`
-KeyPackage does not relax this limit.
+extension, MUST be current at validation time (the validation time is not before `not_before` and not after `not_after`),
+and MUST have `not_after - not_before <= 7,261,200` seconds. The range is 84 days plus a one-hour clock-skew margin. A
+`last_resort` KeyPackage does not relax this limit.
 
 When a transport exposes a publication timestamp or replacement rule, clients SHOULD use it to avoid consuming stale
 single-use KeyPackages. If two otherwise equivalent candidates remain, clients SHOULD use a deterministic
@@ -93,8 +93,8 @@ available so the inviter can retry or choose another candidate.
 A client MUST reject a published KeyPackage when:
 
 - the decoded content is not a valid MLS KeyPackage;
-- the KeyPackage `Lifetime` extension is missing, expired, not yet valid, or has a total range longer than
-  7,261,200 seconds;
+- the KeyPackage `Lifetime` extension is missing, the validation time is before `not_before` or after `not_after`, or
+  the total range is longer than 7,261,200 seconds;
 - the credential identity is not a valid Marmot account identity;
 - the account identity proof extension is missing or invalid;
 - the transport author or sender does not match the credential identity under the active transport binding;

--- a/transports/nostr.md
+++ b/transports/nostr.md
@@ -54,6 +54,36 @@ Producers SHOULD use `wss`, lowercase DNS hostnames, omit default ports, and avo
 compare relay URL byte strings exactly after validation. Local safety policy MAY refuse to connect or publish to a
 valid relay URL, but it does not rewrite signed group state.
 
+## Event identity and tag cardinality
+
+A receiver MUST verify a signed Nostr event's NIP-01 id and signature before treating its `id`, `pubkey`, `created_at`,
+`kind`, `tags`, or `content` as authenticated transport metadata. Before that verification succeeds, those fields are
+untrusted bytes and MUST NOT be used as trusted routing, replay, telemetry, or KeyPackage evidence.
+
+Required Marmot transport tags have exact cardinality. If a required singleton tag is missing, repeated, has no value,
+or has extra values beyond the one defined here, the event is malformed. If a required list tag is missing, repeated,
+empty, or contains duplicate values after validation, the event is malformed. A receiver MUST NOT read only the first
+matching tag and ignore later duplicates.
+
+| Event shape | Tag | Cardinality and value rule |
+| --- | --- | --- |
+| kind `445` group message | `h` | exactly one tag, exactly one value: lowercase hex `nostr_group_id` |
+| kind `1059` welcome gift wrap | `p` | exactly one tag, exactly one value: lowercase hex account identity of the recipient |
+| kind `444` welcome rumor | `e` | exactly one tag, exactly one value: lowercase hex Nostr event id of the claimed KeyPackage event |
+| kind `444` welcome rumor | `relays` | exactly one tag, one or more relay URL values using the relay URL profile |
+| kind `30443` KeyPackage | `d` | exactly one tag, exactly one non-empty slot id value |
+| kind `30443` KeyPackage | `mls_protocol_version` | exactly one tag, exactly one value: `1.0` |
+| kind `30443` KeyPackage | `i` | exactly one tag, exactly one value: lowercase hex KeyPackageRef |
+| kind `30443` KeyPackage | `mls_ciphersuite` | exactly one id-list tag |
+| kind `30443` KeyPackage | `mls_extensions` | exactly one id-list tag |
+| kind `30443` KeyPackage | `mls_proposals` | exactly one id-list tag |
+| kind `30443` KeyPackage | `app_components` | exactly one id-list tag |
+
+The kind `444` `e` tag is a claim about which KeyPackage event was consumed. It is not proof that the event exists, was
+authored by the invitee account, or carried the decoded KeyPackage. A client that needs those facts MUST fetch and
+verify the referenced kind `30443` event and then verify the decoded KeyPackageRef under
+[../foundation/key-packages.md](../foundation/key-packages.md).
+
 ## Group message delivery
 
 Nostr group messages use Nostr kind `445`.
@@ -204,10 +234,11 @@ The current tag set is:
 whose values follow the tag name in a single tag array, for example `["mls_extensions", "0x0006", "0xf2f1", "0x000a"]`.
 A producer MUST NOT split the ids of one list across repeated tags. Each value is the `0x`-prefixed lowercase
 hexadecimal encoding of the 16-bit id, zero-padded to four hex digits, such as `0x0001` or `0xf2f1`. Each id-list tag
-MUST carry at least one value. Consumers compare id-list values as exact strings; under the text rule in
-[../foundation/canonical-encoding.md](../foundation/canonical-encoding.md), the producer emits exactly this form. A
-consumer MUST reject a KeyPackage event that carries more than one tag with the same id-list name (so the producer's
-"exactly one tag" rule is enforced, not assumed); it MUST NOT read only the first occurrence and ignore the rest.
+MUST carry at least one value and MUST NOT repeat a value inside the same tag. Consumers compare id-list values as exact
+strings; under the text rule in [../foundation/canonical-encoding.md](../foundation/canonical-encoding.md), the producer
+emits exactly this form. A consumer MUST reject a KeyPackage event that carries more than one tag with the same id-list
+name (so the producer's "exactly one tag" rule is enforced, not assumed); it MUST NOT read only the first occurrence
+and ignore the rest.
 
 The `i` tag is the KeyPackageRef, not the account identity. Receivers MUST verify it against the decoded KeyPackage.
 
@@ -269,12 +300,12 @@ lifecycle defines when locally created MLS work MAY be applied.
 
 A Nostr transport client MUST validate the outer event enough to classify it before passing bytes to the MLS peeler:
 
-- kind `445` group messages MUST be signed Nostr events with a valid id/signature, MUST have exactly one `h` tag, and
-  MUST have base64 content whose decoded length is at least 28 bytes;
-- kind `1059` welcomes MUST be signed Nostr events and MUST have a `p` tag;
-- kind `444` welcome rumors MUST have `e` and `relays` tags after NIP-59 unwrapping;
+- kind `445` group messages MUST be signed Nostr events with a valid id/signature, MUST satisfy the `h` tag rule above,
+  and MUST have base64 content whose decoded length is at least 28 bytes;
+- kind `1059` welcomes MUST be signed Nostr events with a valid id/signature and MUST satisfy the `p` tag rule above;
+- kind `444` welcome rumors MUST satisfy the `e` and `relays` tag rules above after NIP-59 unwrapping;
 - kind `30443` KeyPackage event content MUST be base64-encoded `MLSMessage` bytes whose wire format is
-  `mls_key_package`;
+  `mls_key_package`, and MUST satisfy the KeyPackage tag rules above;
 - fields that claim to be hex or base64 MUST decode successfully;
 - unsupported Nostr kinds are ignored or reported as malformed transport input.
 

--- a/transports/nostr.md
+++ b/transports/nostr.md
@@ -56,14 +56,14 @@ valid relay URL, but it does not rewrite signed group state.
 
 ## Event identity and tag cardinality
 
-A receiver MUST verify a signed Nostr event's NIP-01 id and signature before treating its `id`, `pubkey`, `created_at`,
-`kind`, `tags`, or `content` as authenticated transport metadata. Before that verification succeeds, those fields are
-untrusted bytes and MUST NOT be used as trusted routing, replay, telemetry, or KeyPackage evidence.
+**CRITICAL:** A receiver MUST verify a signed Nostr event's NIP-01 id and signature before treating its `id`, `pubkey`,
+`created_at`, `kind`, `tags`, or `content` as authenticated transport metadata. Before that verification succeeds, those
+fields are untrusted bytes and MUST NOT be used as trusted routing, replay, telemetry, or KeyPackage evidence.
 
-Required Marmot transport tags have exact cardinality. If a required singleton tag is missing, repeated, has no value,
-or has extra values beyond the one defined here, the event is malformed. If a required list tag is missing, repeated,
-empty, or contains duplicate values after validation, the event is malformed. A receiver MUST NOT read only the first
-matching tag and ignore later duplicates.
+**CRITICAL:** Required Marmot transport tags have exact cardinality. If a required singleton tag is missing, repeated,
+has no value, or has extra values beyond the one defined here, the event is malformed. If a required list tag is missing,
+repeated, empty, or contains duplicate values after validation, the event is malformed. A receiver MUST NOT read only the
+first matching tag and ignore later duplicates.
 
 | Event shape | Tag | Cardinality and value rule |
 | --- | --- | --- |
@@ -79,9 +79,9 @@ matching tag and ignore later duplicates.
 | kind `30443` KeyPackage | `mls_proposals` | exactly one id-list tag |
 | kind `30443` KeyPackage | `app_components` | exactly one id-list tag |
 
-The kind `444` `e` tag is a claim about which KeyPackage event was consumed. It is not proof that the event exists, was
-authored by the invitee account, or carried the decoded KeyPackage. A client that needs those facts MUST fetch and
-verify the referenced kind `30443` event and then verify the decoded KeyPackageRef under
+The kind `444` `e` tag sits on the trust boundary: it is a claim about which KeyPackage event was consumed. It is not
+proof that the event exists, was authored by the invitee account, or carried the decoded KeyPackage. A client that needs
+those facts MUST fetch and verify the referenced kind `30443` event and then verify the decoded KeyPackageRef under
 [../foundation/key-packages.md](../foundation/key-packages.md).
 
 ## Group message delivery


### PR DESCRIPTION
## Summary

- define unambiguous tuple/preimage boundaries for Marmot-owned signed, hashed, stored, compared, and named bytes
- pin the KeyPackage lifetime acceptance rule to 84 days plus a one-hour skew margin
- add a Nostr tag-cardinality table covering group `h`, gift-wrap `p`, welcome `e`/`relays`, and KeyPackage tags
- state that unverified Nostr event ids and metadata are not trusted routing/replay/telemetry evidence

## Companion implementation

- marmot-protocol/mdk#735 closes the remaining open child issues: mdk#349, mdk#386, and mdk#398.

## Verification

- rg -n "the spec should|spec MUST|Spec-Defined|GroupEvent|\bengine\b|darkmatter" .
- rg -n "PendingStateRef|drain_auto_publish|confirm_published|publish_failed" .
- rg -n "relay hints|internal version|public registry" .

The remaining matches are existing AGENTS/implementation-model guidance and existing push-notification relay-hint text.

Closes #77

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/marmot/pull/236">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified rules for encoding multi-field values so boundaries remain unambiguous and collision-resistant.
  * Tightened KeyPackage validity guidance, including required lifetime checks and rejection conditions.
  * Strengthened Nostr event validation rules, including authenticated metadata, required tag counts, duplicate-tag handling, and pre-processing checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->