### PR TITLE
Specify terminal MLS group disbanding

### DIFF
--- a/app-components/README.md
+++ b/app-components/README.md
@@ -117,6 +117,11 @@ new Marmot group MUST list it among the group's required proposal capabilities. 
 mutable GroupContext component state, including the required admin-policy component, so this requirement is not
 conditional on enabling a particular optional component.
 
+New groups also require `marmot.group.lifecycle.v1` (`0x800c`) with `active`
+state. Existing groups that predate that component remain valid without it and
+use the explicit enablement flow in
+[group-lifecycle-v1.md](./group-lifecycle-v1.md).
+
 ## Common Rules
 
 All state and update payloads use the Marmot binary profile unless a component says otherwise.

--- a/app-components/README.md
+++ b/app-components/README.md
@@ -252,6 +252,7 @@ The currently adopted persistent GroupContext components are:
 - [marmot.group.message-retention.v1](./message-retention-v1.md)
 - [marmot.group.avatar-url.v1](./group-avatar-url-v1.md)
 - [marmot.group.encrypted-media.v2](./group-encrypted-media-v2.md)
+- [marmot.group.lifecycle.v1](./group-lifecycle-v1.md)
 
 The following persistent GroupContext component is experimental and is not required for baseline Marmot conformance:
 

--- a/app-components/admin-policy-v1.md
+++ b/app-components/admin-policy-v1.md
@@ -128,6 +128,13 @@ Marmot group. An AppDataUpdate `remove` operation targeting this component is in
 active admin, is authorized to commit one. Deleting or abandoning a local group is not a component removal and does not
 require a group-state commit.
 
+The terminal disband Commit defined by
+[group-lifecycle-v1.md](./group-lifecycle-v1.md) is the only coupled operation
+that may remove every other admin/member at once. Its resulting admin list MUST
+contain exactly the authenticated committer's account so the final mechanical
+MLS state still satisfies the nonempty-admin and admin/leaf invariants before
+live MLS state is deleted.
+
 If every active admin loses access to all of its signing devices or keys, v1 has no in-band succession, override, or
 automatic-promotion mechanism. The group remains cryptographically valid, and ordinary application messages and
 non-admin SelfRemove may continue, but admin-gated membership and settings changes are permanently frozen. Members must

--- a/app-components/group-lifecycle-v1.md
+++ b/app-components/group-lifecycle-v1.md
@@ -1,0 +1,119 @@
+# marmot.group.lifecycle.v1
+
+Status: adopted.
+
+## Registry
+
+- Component id: `0x800c`
+- Name: `marmot.group.lifecycle.v1`
+- Location: GroupContext `app_data_dictionary`
+- Default requirement: required for newly created groups
+
+## State
+
+```text
+enum {
+  active(0),
+  disbanded(1)
+} MarmotGroupLifecycleV1;
+```
+
+The encoded state is exactly one byte. `0x00` is `active` and `0x01` is
+`disbanded`. Every other value and every encoding with trailing bytes is
+invalid.
+
+`active` means the authenticated group has not terminated. The client's local
+protocol lifecycle can still be `Stable`, `PendingPublish`, `Merging`,
+`Recovering`, or `Unrecoverable`.
+
+`disbanded` is the terminal sixth group lifecycle state. It is absorbing:
+clients do not process later group traffic, select a later branch, or rejoin
+the same group id after accepting a selected disband Commit. A replacement
+conversation uses a newly created MLS group.
+
+## Enablement for existing groups
+
+A group that predates this component MAY omit it and MAY omit `0x800c` from its
+required `app_components` list. Such a group remains valid but cannot be
+disbanded.
+
+An active admin MAY enable disbanding in one Commit that:
+
+- adds the `active` state if it is absent; and
+- adds `0x800c` to the required `app_components` list.
+
+The resulting state is valid only when every resulting member leaf advertises
+support for `0x800c`. Enablement does not disband the group and produces no
+group-system row.
+
+Once required, this component MUST remain present and required for the
+remainder of the group's lifetime.
+
+## Disband update and Commit shape
+
+The only state transition is `active -> disbanded`. A disband update MUST be
+inline in the Commit that realizes it; a standalone or by-reference disband
+proposal is invalid.
+
+A Commit carrying the transition is valid only when:
+
+- the authenticated committer is an active admin in the candidate parent;
+- `0x800c` is already required in the candidate parent;
+- the resulting lifecycle state is `disbanded`;
+- the resulting admin-policy list contains exactly the committer's Marmot
+  account identity;
+- every candidate-parent leaf except the exact committing leaf is removed,
+  including other leaves for the committer's account;
+- it contains no Add, Update, PreSharedKey, ReInit, ExternalInit,
+  GroupContextExtensions, AppEphemeral, Custom, unrelated AppDataUpdate, or
+  other proposal; and
+- the resulting state satisfies normal MLS and Marmot validation.
+
+The Commit carries a full admin-policy replacement even when the committer was
+already the sole admin. A single-leaf group therefore produces a valid disband
+Commit with no Remove proposals.
+
+## Convergence and realization
+
+A valid disband Commit is never terminalized by the direct linear-apply seam.
+After publication, or after inbound validation, the client retains it as
+candidate material and opens a bounded convergence pass. Normal branch
+selection applies; disband receives no special ordering priority.
+
+While a local irreversible disband request is unresolved, the client holds a
+durable `Disbanding` gate. `Disbanding` is not a canonical lifecycle state. It
+blocks new outbound work and survives publication failure, restart, and a
+losing branch. If an active branch is selected, an authorized client
+regenerates the Commit against that selected state. If any valid disband branch
+is selected, the request succeeds regardless of which admin authored the
+selected Commit.
+
+Only a selected disband Commit moves the lifecycle from `Recovering` to
+`Disbanded`. The client then:
+
+- emits one actor-attributed `group_disbanded` state notification;
+- does not emit member/admin removal presentation rows for the same Commit;
+- retains a read-only authenticated tombstone and MAY retain delivered
+  application history; and
+- deletes live MLS state and stops routing, sending, maintenance, and
+  convergence for the group.
+
+The final committer leaf is a mechanical MLS requirement and is not an active
+Marmot participant after terminalization.
+
+## Authorization failure
+
+A durable local request that becomes impossible because the requester is no
+longer an admin or no longer a member ends with a local typed failure. Transport
+failure and `Unrecoverable` do not cancel the request; they leave it pending
+until publication can resume or a verified repair restores state.
+
+## Removal
+
+This component cannot be removed while present. An AppDataUpdate `remove`
+operation targeting it is invalid.
+
+## Migration
+
+This is the first versioned lifecycle component. A breaking wire or validation
+change receives a new component id and document.

--- a/app-components/group-lifecycle-v1.md
+++ b/app-components/group-lifecycle-v1.md
@@ -75,10 +75,13 @@ Commit with no Remove proposals.
 
 ## Convergence and realization
 
-A valid disband Commit is never terminalized by the direct linear-apply seam.
-After publication, or after inbound validation, the client retains it as
-candidate material and opens a bounded convergence pass. Normal branch
-selection applies; disband receives no special ordering priority.
+A valid disband Commit is never terminalized through ordinary linear
+advancement. After publication, or after inbound validation, the client retains
+it as candidate material and opens a bounded convergence pass. Admission of the
+valid disband candidate changes the lifecycle from `Stable` to `Recovering`
+even when no divergent edge exists. This forced transition does not assert that
+a fork exists and does not change normal branch selection; disband receives no
+special ordering priority.
 
 While a local irreversible disband request is unresolved, the client holds a
 durable `Disbanding` gate. `Disbanding` is not a canonical lifecycle state. It

--- a/foundation/application-messages.md
+++ b/foundation/application-messages.md
@@ -129,7 +129,8 @@ when the target arrives, or drop it. Either choice is acceptable.
 ## Group system events (kind 1210)
 
 Kind `1210` is a durable group system row: a record of an authenticated change to group state — a member added,
-removed, or left; an admin granted or revoked; the group renamed; the group avatar changed. These rows are not chat.
+removed, or left; an admin granted or revoked; the group renamed; the group avatar changed; or the group disbanded.
+These rows are not chat.
 A client MUST render them separately from kind `9` chat bubbles and MUST NOT treat their `content` as a chat body.
 
 A kind `1210` row is **synthesized locally** from canonical group state, not sent as a message. When a client applies a
@@ -154,12 +155,17 @@ The `content` is JSON:
 
 - `v` is the schema version (`1`).
 - `system_type` names the change. Defined values: `member_added`, `member_removed`, `member_left`, `admin_added`,
-  `admin_removed`, `group_renamed`, `group_avatar_changed`.
+  `admin_removed`, `group_renamed`, `group_avatar_changed`, `group_disbanded`.
 - `text` is a human-readable fallback only. Clients SHOULD render from `system_type` plus `data` so the row can be
   localized and re-resolved as display names change.
 - `data` carries structured fields: `actor` (hex pubkey of the committing member, when attributable), `subject` (hex
   pubkey of the member the change concerns, for the member/admin types), and `name` (the new group name, for
   `group_renamed`).
+
+`group_disbanded` carries the authenticated committer in `actor` and no
+`subject`. It is the only presentation row synthesized for the terminal
+Commit; the Commit's coupled member/admin removals do not produce additional
+kind `1210` rows.
 
 The event SHOULD carry a `["system", system_type]` tag. A row is anchored to the epoch the change reached, so it sorts
 into history at the point the change took effect.

--- a/foundation/application-messages.md
+++ b/foundation/application-messages.md
@@ -167,6 +167,26 @@ The `content` is JSON:
 Commit; the Commit's coupled member/admin removals do not produce additional
 kind `1210` rows.
 
+A complete unsigned kind `1210` Marmot app event for `group_disbanded` is:
+
+```json
+{
+  "id": "126e47076e4d0a75ed260b279c33ed433acd764fc80e2de2e0315a64116d1f52",
+  "pubkey": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+  "created_at": 1700000000,
+  "kind": 1210,
+  "tags": [["system", "group_disbanded"]],
+  "content": "{\"v\":1,\"system_type\":\"group_disbanded\",\"text\":\"Group disbanded\",\"data\":{\"actor\":\"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798\"}}"
+}
+```
+
+The `id` above is the lowercase-hex SHA-256 of these exact canonical
+Nostr-event preimage bytes:
+
+```text
+[0,"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",1700000000,1210,[["system","group_disbanded"]],"{\"v\":1,\"system_type\":\"group_disbanded\",\"text\":\"Group disbanded\",\"data\":{\"actor\":\"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798\"}}"]
+```
+
 The event SHOULD carry a `["system", system_type]` tag. A row is anchored to the epoch the change reached, so it sorts
 into history at the point the change took effect.
 

--- a/foundation/registries.md
+++ b/foundation/registries.md
@@ -23,6 +23,7 @@ Marmot app components use MLS private-use component ids.
 | `0x8009`     | `marmot.member.account-identity-proof.v2`       | [doc](../app-components/account-identity-proof-v2.md)               |
 | `0x800a`     | `marmot.authorization.multi-device-join.v1`     | [draft](../app-components/multi-device-join-authorization-v1.md)    |
 | `0x800b`     | `marmot.group.encrypted-media.v2`               | [doc](../app-components/group-encrypted-media-v2.md)                |
+| `0x800c`     | `marmot.group.lifecycle.v1`                     | [doc](../app-components/group-lifecycle-v1.md)                      |
 
 ## Upstream MLS extension draft ids
 

--- a/layout.md
+++ b/layout.md
@@ -49,6 +49,7 @@ app-components/
   group-avatar-url-v1.md
   group-encrypted-media-v1.md
   group-encrypted-media-v2.md
+  group-lifecycle-v1.md
   account-identity-proof-v2.md
   multi-device-join-authorization-v1.md
 transports/

--- a/protocol-core/README.md
+++ b/protocol-core/README.md
@@ -66,6 +66,8 @@ find compatible KeyPackage
 - [group-messaging.md](./group-messaging.md) - proposals, commits, and MLS application messages.
 - [member-departure.md](./member-departure.md) - SelfRemove and member departure rules.
 - [group-state.md](./group-state.md) - the per-group lifecycle states and legal transitions.
+- [../app-components/group-lifecycle-v1.md](../app-components/group-lifecycle-v1.md) - authenticated terminal group
+  disbanding and legacy-group enablement.
 - [publish-lifecycle.md](./publish-lifecycle.md) - publish-before-apply for local group-state changes.
 - [inbound-processing.md](./inbound-processing.md) - how incoming bytes are stored, classified, and retried.
 - [convergence.md](./convergence.md) - how candidate branches are built, scored, selected, and applied.

--- a/protocol-core/convergence.md
+++ b/protocol-core/convergence.md
@@ -67,6 +67,11 @@ divergent edge becomes available before that cutoff, the same pass changes the g
 `Recovering`. It MUST NOT restart either timer, resnapshot `pass_base_epoch`, or briefly apply the formerly linear edge
 as canonical state.
 
+A valid candidate edge that changes `marmot.group.lifecycle.v1` to `disbanded` also changes the lifecycle from `Stable`
+to `Recovering` when it is admitted, even when it is a linear edge and no divergent edge exists. This forced transition
+does not assert that the candidate set is forked, restart either timer, resnapshot `pass_base_epoch`, or give the
+disband candidate special branch-scoring priority.
+
 The absolute pass deadline starts when the pass starts and MUST NOT restart. A client closes the pass at the earlier of:
 
 1. `settlement_quiescence_ms` elapsing without selection-relevant input; or
@@ -108,10 +113,13 @@ divergent edge then provide at least two candidate branches from a shared `fork_
 `Recovering` and open a bounded convergence pass before convergence selects and applies a branch.
 
 A valid Commit that advances the current canonical tip, with no divergent eligible edge, is linear advancement and does
-not by itself enter `Recovering`; it still follows the bounded-pass apply timing above. A Commit with an unavailable
-parent remains deferred and does not trigger recovery until replay against retained state produces a valid divergent
-edge. Invalid, stale, duplicate, or outside-horizon input does not trigger recovery. Fork detection derives parentage
-from validated MLS bytes and retained states, never from transport metadata.
+not by itself enter `Recovering`; it still follows the bounded-pass apply timing above. The exception is a valid
+Commit that changes `marmot.group.lifecycle.v1` to `disbanded`: admission of that candidate forces
+`Stable -> Recovering` so terminalization can occur only after selection, whether or not a divergent edge exists. A
+Commit with an unavailable parent remains deferred and does not trigger recovery until replay against retained state
+produces a valid divergent edge or validates it as the disband exception. Invalid, stale, duplicate, or outside-horizon
+input does not trigger recovery. Fork detection derives parentage from validated MLS bytes and retained states, never
+from transport metadata.
 
 ## Candidate branches
 
@@ -338,8 +346,10 @@ branch recovery, and app payload invalidation.
 When the selected branch ends in `disbanded`, the client emits exactly one
 actor-attributed `group_disbanded` notification and suppresses presentation
 notifications for the member/admin removals carried by that same Commit. The
-client then releases live MLS and convergence state. Later branches cannot
-supersede a terminalized disband copy.
+leaf-scoped removal outcome and self-removal realization still apply for each
+local leaf removed by the Commit, but they do not produce another presentation
+row. The client then releases live MLS and convergence state. Later branches
+cannot supersede a terminalized disband copy.
 
 State notifications are derived only from accepted commits on the selected branch and the canonical resulting state
 they produce. A state notification derived from a commit is attributed to that commit's `commit_digest` (the same

--- a/protocol-core/convergence.md
+++ b/protocol-core/convergence.md
@@ -134,6 +134,11 @@ match is not an authorization failure and cannot reject the Commit. The Commit c
 parent when all checks succeed. A candidate edge whose resulting state fails Marmot component invariants MUST NOT be
 created, so convergence can never select that invalid transition.
 
+A valid Commit that changes `marmot.group.lifecycle.v1` to `disbanded` is
+always admitted through a bounded convergence pass, even when it would
+otherwise be a linear edge. This mandatory pass is a terminalization boundary,
+not a new branch-scoring rule.
+
 If no retained state passes the Commit's parent-dependent MLS authentication, the Commit remains deferred while its
 authenticated source epoch is inside or ahead of the rollback horizon. Once authentication identifies its candidate
 parent, a failed authorization check is terminal `authorization_failed`. An implementation MUST NOT infer terminal
@@ -329,6 +334,12 @@ The client then assigns dispositions (the disposition vocabulary is pinned in
 Applying the selected branch also produces application-visible state notifications for changes the application MAY need
 to render or act on. Examples include epoch advancement, member additions, member removals, app component changes,
 branch recovery, and app payload invalidation.
+
+When the selected branch ends in `disbanded`, the client emits exactly one
+actor-attributed `group_disbanded` notification and suppresses presentation
+notifications for the member/admin removals carried by that same Commit. The
+client then releases live MLS and convergence state. Later branches cannot
+supersede a terminalized disband copy.
 
 State notifications are derived only from accepted commits on the selected branch and the canonical resulting state
 they produce. A state notification derived from a commit is attributed to that commit's `commit_digest` (the same

--- a/protocol-core/group-setup.md
+++ b/protocol-core/group-setup.md
@@ -34,6 +34,11 @@ selected by the feature set. The GroupContext `app_components` list MUST require
 selected feature set, including any required component whose data appears only in member LeafNodes rather than in the
 GroupContext dictionary.
 
+Newly created groups MUST also require component id `0x800c` and contain
+`marmot.group.lifecycle.v1 = active`. Groups created before adoption of that
+component remain valid without it and cannot disband until an active admin
+completes its explicit negotiated enablement.
+
 The account-proof and admin-policy requirements are lifetime invariants, not creation defaults. Every resulting epoch
 MUST require component ids `0x8009` and `0x8003` in the GroupContext `app_components` list, every member leaf MUST
 advertise and carry a valid `0x8009` proof, and the GroupContext MUST retain the `marmot.group.admin-policy.v1` entry.

--- a/protocol-core/group-state.md
+++ b/protocol-core/group-state.md
@@ -13,7 +13,8 @@ The group lifecycle has six states:
 - `PendingPublish`: the client has prepared a local group-state commit, but has not confirmed that the required bytes
   were published.
 - `Merging`: publication was confirmed, and the client is applying the staged commit to its local canonical state.
-- `Recovering`: the client detected a fork-shaped conflict and is trying to select a safe branch from retained state.
+- `Recovering`: the client is selecting a safe branch from retained state after detecting a fork-shaped conflict or
+  admitting a valid disband candidate that requires terminal convergence.
 - `Unrecoverable`: the client cannot safely select a branch from its retained local material.
 - `Disbanded`: an authenticated disband Commit was selected by a bounded convergence pass. The group is terminal,
   read-only, and cannot resume or rejoin under the same group id.
@@ -61,7 +62,7 @@ PendingPublish
 Merging
   -> Stable              staged commit applied
 Stable
-  -> Recovering          fork detected and retained recovery is required
+  -> Recovering          fork detected, or valid disband candidate admitted
 Stable
   -> Unrecoverable       required retained state is permanently missing or corrupt
 Recovering
@@ -77,12 +78,17 @@ Disbanded
 ```
 
 Fork detection runs only from `Stable`, against settled canonical state, using the operational rule in
-[convergence.md](./convergence.md) ("Fork detection"). Linear advancement does not enter `Recovering`. There is no
-`Merging -> Recovering` edge: a competing branch observed while the client is applying its own confirmed commit is
-retained, the merge completes to `Stable`, and fork detection then runs from `Stable`. `Recovering` re-entry is implicit:
+[convergence.md](./convergence.md) ("Fork detection"). Ordinary linear advancement does not enter `Recovering`. A valid
+Commit that changes `marmot.group.lifecycle.v1` to `disbanded` is the exception: admitting that candidate into its
+mandatory bounded pass changes `Stable -> Recovering` even when no divergent edge exists. This exception does not
+classify the candidate set as forked or change branch scoring.
+
+There is no `Merging -> Recovering` edge: a competing branch or locally published disband Commit observed while the
+client is applying its own confirmed commit is retained, the merge completes to `Stable`, and admission into the
+bounded pass then triggers the applicable `Stable -> Recovering` rule. `Recovering` re-entry is implicit:
 convergence-relevant input that arrives while the group is already in `Recovering` and before the bounded pass cutoff is
 folded into that recovery pass. Input retained after the cutoff belongs to a later pass. The group stays in `Recovering`
-until a branch is selected and applied (`-> Stable`) or no safe branch exists (`-> Unrecoverable`).
+until a branch is selected and applied (`-> Stable` or `-> Disbanded`) or no safe branch exists (`-> Unrecoverable`).
 
 The direct `Stable -> Unrecoverable` transition applies when normal linear processing discovers that required retained
 history or authenticated state inside the rollback horizon is permanently unavailable or corrupt and no defined
@@ -155,11 +161,12 @@ is the `Unrecoverable` condition: when recovery has no safe branch and no repair
 `Unrecoverable`. `PendingPublish` and `Merging` are local-publish states, not convergence passes, so convergence status
 is not meaningful while the group is in them.
 
-A disband Commit is the exception to ordinary linear advancement: even without
-a detected fork it opens a bounded convergence pass before the application
-observes `Disbanded`. Publication may pass internally through `Merging` and
-`Stable`, but terminal application occurs only through
-`Recovering -> Disbanded`.
+A disband Commit is the exception to ordinary linear advancement. When a valid
+disband candidate is admitted from `Stable`, the client enters `Recovering`
+even without a detected fork and runs the mandatory bounded convergence pass.
+Publication may pass internally through `Merging` and `Stable`, but terminal
+application occurs only through `Recovering -> Disbanded`. Selection of an
+active branch instead returns the lifecycle to `Stable`.
 
 ## Local actions during convergence
 

--- a/protocol-core/group-state.md
+++ b/protocol-core/group-state.md
@@ -7,7 +7,7 @@ only one state is visible as the group's canonical state.
 
 ## Lifecycle states
 
-The group lifecycle has five states:
+The group lifecycle has six states:
 
 - `Stable`: the group has a canonical MLS epoch. Normal inbound processing and outbound work MAY proceed.
 - `PendingPublish`: the client has prepared a local group-state commit, but has not confirmed that the required bytes
@@ -15,10 +15,16 @@ The group lifecycle has five states:
 - `Merging`: publication was confirmed, and the client is applying the staged commit to its local canonical state.
 - `Recovering`: the client detected a fork-shaped conflict and is trying to select a safe branch from retained state.
 - `Unrecoverable`: the client cannot safely select a branch from its retained local material.
+- `Disbanded`: an authenticated disband Commit was selected by a bounded convergence pass. The group is terminal,
+  read-only, and cannot resume or rejoin under the same group id.
 
 `Unrecoverable` is local to one client. It does not mean the Marmot group is dead. It means that this client MUST repair
 its group state, restore retained material, rejoin, or discard the local group copy before it can safely send or apply
 more group traffic.
+
+`Disbanded` is authenticated canonical group state backed by
+`marmot.group.lifecycle.v1`. It is absorbing and has no repair or rejoin
+transition. A replacement conversation creates a new group.
 
 `Stable` is the only state where a client MAY prepare a new local group-state commit. Outbound app payloads are also
 held while convergence input is unresolved, because they MUST be encrypted against the selected canonical state.
@@ -27,6 +33,13 @@ A member that has sent a SelfRemove proposal also enters the local `Leaving` gat
 [member-departure.md](./member-departure.md). `Leaving` is not a canonical group lifecycle state: the MLS group state
 still contains the member until a commit removes it. It is a durable outbound restriction on the leaving client and may
 span multiple epoch-bound SelfRemove proposals.
+
+An admin whose irreversible disband request is unresolved enters the durable
+local `Disbanding` gate defined in
+[../app-components/group-lifecycle-v1.md](../app-components/group-lifecycle-v1.md).
+Like `Leaving`, `Disbanding` is not a canonical lifecycle state. It blocks all
+new outbound work while the request is prepared, published, retried, or
+evaluated by convergence.
 
 A member whose own removal has been realized holds the group as a removed, inactive copy per
 [member-departure.md](./member-departure.md) ("Realizing removal"). Like `Leaving`, this is not a canonical lifecycle
@@ -54,9 +67,13 @@ Stable
 Recovering
   -> Stable              a canonical branch was selected and applied
 Recovering
+  -> Disbanded           a selected branch terminates the group
+Recovering
   -> Unrecoverable       no safe branch can be selected from retained local material
 Unrecoverable
   -> Stable              state was repaired, restored, or replaced by a verified join
+Disbanded
+  -> (none)              terminal
 ```
 
 Fork detection runs only from `Stable`, against settled canonical state, using the operational rule in
@@ -73,7 +90,8 @@ authenticated repair path can restore it. A client does not enter `Recovering` m
 `Unrecoverable` when no fork recovery is possible.
 
 A client MUST reject a local group-state commit while the group is in `PendingPublish`, `Merging`, `Recovering`, or
-`Unrecoverable`.
+`Unrecoverable`. A `Disbanded` client rejects all local and inbound group
+traffic.
 
 Inbound group messages MAY be retained in any non-`Stable` state. Whether retained inbound may change canonical group
 state depends on the state:
@@ -83,6 +101,8 @@ state depends on the state:
   changes only when a selected branch is applied (see below);
 - during `Unrecoverable`, retained inbound MUST NOT be applied to canonical group state until a verified repair path
   restores, repairs, or replaces the local group state.
+- during `Disbanded`, inbound is not retained or applied and receives the
+  `unknown_group` pre-convergence category.
 
 While a group is in `Recovering`, a client MAY process or reprocess retained input to build candidate branches, score
 them, and select a canonical branch. That processing MUST NOT release outbound work or emit delivered app payloads until
@@ -126,7 +146,7 @@ The legal combinations are:
 | ------------------ | --------------------------------- | --------------------------------------------------------------------- |
 | `Syncing`          | `Stable`, `Recovering`            | bounded pass still collecting selection-relevant input                |
 | `Resolving`        | `Stable`, `Recovering`            | frozen-batch fixed-point work; no waiting or new input                |
-| `Settled`          | `Stable`                          | fixed point reached and any selected branch applied                   |
+| `Settled`          | `Stable`, `Disbanded`             | fixed point reached and any selected branch applied                   |
 | `Blocked`          | `Recovering`, `Unrecoverable`     | needs a repair path or missing retained material                      |
 
 Two couplings follow from this table. A group leaves `Recovering` for `Stable` only after convergence reaches
@@ -134,6 +154,12 @@ Two couplings follow from this table. A group leaves `Recovering` for `Stable` o
 is the `Unrecoverable` condition: when recovery has no safe branch and no repair path, the lifecycle moves to
 `Unrecoverable`. `PendingPublish` and `Merging` are local-publish states, not convergence passes, so convergence status
 is not meaningful while the group is in them.
+
+A disband Commit is the exception to ordinary linear advancement: even without
+a detected fork it opens a bounded convergence pass before the application
+observes `Disbanded`. Publication may pass internally through `Merging` and
+`Stable`, but terminal application occurs only through
+`Recovering -> Disbanded`.
 
 ## Local actions during convergence
 

--- a/protocol-core/inbound-processing.md
+++ b/protocol-core/inbound-processing.md
@@ -106,6 +106,7 @@ State notifications include events such as:
 - member added or removed, including the local member's own removal (see
   [member-departure.md](./member-departure.md), "Realizing removal");
 - component state changed;
+- group disbanded by an authenticated admin;
 - branch recovered;
 - app payload invalidated because its MLS application message belonged only to a losing branch;
 - group-state change invalidated because the commit it was derived from was superseded by branch selection.
@@ -120,6 +121,9 @@ State notifications track the selected canonical branch. When convergence supers
 applied, the client MUST emit a group-state-change invalidation naming the superseded commit, and state notifications
 attributed to that commit are withdrawn from application output (see [convergence.md](./convergence.md), "Applying the
 selected branch"), so the application never keeps rendering a group-state change that the canonical state contradicts.
+
+The selected disband notification is terminal and is not withdrawn: after
+terminalization the local copy no longer participates in convergence.
 
 ## Delivered app payloads
 

--- a/protocol-core/member-departure.md
+++ b/protocol-core/member-departure.md
@@ -131,10 +131,14 @@ A removed group copy is retained inactive, not deleted. The removed member:
 - MAY retain previously delivered content and group history for local display;
 - MAY discard the local group copy at any time.
 
-When the removing Commit is a selected disband Commit, the group-level
-`Disbanded` state takes presentation precedence over leaf departure. The client
-records its leaf-scoped membership outcome but emits the single
-`group_disbanded` row instead of a separate member-removal row.
+When a selected disband Commit removes the local leaf, the client MUST still
+complete the leaf-scoped realization above: it records the membership outcome,
+retains its authenticated evidence, and emits the `self-removed` state
+notification. The group-level `Disbanded` state takes presentation precedence,
+so that notification MUST NOT synthesize a separate member-removal row. The
+single `group_disbanded` row is the only presentation row for the Commit.
+Suppressing the duplicate row MUST NOT discard the local membership outcome or
+its evidence.
 
 The removed condition is terminal for that local leaf. The client does not retain old epoch secrets or run convergence
 in order to resurrect it if continuing members later select another branch. Rejoining requires explicitly discarding

--- a/protocol-core/member-departure.md
+++ b/protocol-core/member-departure.md
@@ -131,6 +131,11 @@ A removed group copy is retained inactive, not deleted. The removed member:
 - MAY retain previously delivered content and group history for local display;
 - MAY discard the local group copy at any time.
 
+When the removing Commit is a selected disband Commit, the group-level
+`Disbanded` state takes presentation precedence over leaf departure. The client
+records its leaf-scoped membership outcome but emits the single
+`group_disbanded` row instead of a separate member-removal row.
+
 The removed condition is terminal for that local leaf. The client does not retain old epoch secrets or run convergence
 in order to resurrect it if continuing members later select another branch. Rejoining requires explicitly discarding
 the old active cryptographic state and processing a fresh valid Welcome under [joining.md](./joining.md). An


### PR DESCRIPTION
## Summary

- register required app component `0x800c` as `marmot.group.lifecycle.v1`
- define the exact one-byte `Active` / `Disbanded` state and irreversible transition
- specify authenticated disband Commit shape, admin-policy coupling, bounded convergence, terminal absorption, departure behavior, and the actor-attributed kind-1210 row
- add `Disbanded` as the sixth canonical group lifecycle state while keeping `Disbanding` as a durable local gate

## Why

MLS has no built-in group deletion operation. Marmot needs an authenticated, convergent terminal state that prevents old branches, traffic, or Welcomes from resurrecting a group after an administrator disbands it.

## Compatibility

Existing current-profile groups may omit lifecycle-v1, but cannot disband until an administrator enables it in one Commit and every current leaf advertises support. New groups require lifecycle-v1 and start `Active`.

## Validation

- specification registry, layout, component, lifecycle, convergence, setup, inbound-processing, departure, admin-policy, and application-message references updated together
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated group disbanding with a terminal `Disbanded` state.
  * New groups now enable lifecycle tracking by default.
  * Existing groups can explicitly enable disbanding while remaining compatible.
  * Disbanding requires an authorized admin action and permanently prevents further group activity.
  * Added a dedicated `group_disbanded` system event attributed to the authenticated admin.
* **Documentation**
  * Documented lifecycle states, validation rules, convergence behavior, notifications, and compatibility requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->