### PR TITLE
Define convergence assurance and deferred-input semantics

### DIFF
--- a/foundation/README.md
+++ b/foundation/README.md
@@ -18,6 +18,7 @@ Foundation docs SHOULD change slowly. A change here usually means the whole prot
 - [application-messages.md](./application-messages.md) - the unsigned Nostr-shaped payload inside MLS messages.
 - [wire-envelopes.md](./wire-envelopes.md) - the split between application payloads, MLS bytes, and transport envelopes.
 - [mls-protocol.md](./mls-protocol.md) - the MLS protocol pieces Marmot builds on.
+- [conformance.md](./conformance.md) - canonical protocol-state equivalence for deterministic testing.
 - [errors.md](./errors.md) - shared result and rejection vocabulary.
 - [registries.md](./registries.md) - Marmot-owned ids and namespaces.
 

--- a/foundation/conformance.md
+++ b/foundation/conformance.md
@@ -1,0 +1,56 @@
+# Conformance state equivalence
+
+Status: adopted.
+
+This document defines the protocol-state projection used to compare Marmot clients in deterministic conformance tests.
+It defines equality over protocol meaning, not equality over implementation storage.
+
+## Canonical snapshot
+
+A conformance snapshot for one group contains:
+
+- the raw MLS group id;
+- the MLS epoch;
+- `SHA256` of the TLS-serialized MLS `GroupContext`;
+- the exporter commitment defined below;
+- every nonblank leaf in leaf-index order, including its leaf index, Marmot account identity, MLS signature public key,
+  and advertised capabilities;
+- the group-required capabilities;
+- every `GroupContext.extensions.app_data_dictionary` entry in ascending component-id order, including the exact
+  component value bytes;
+- the canonical group lifecycle and current convergence status;
+- the current convergence disposition of every scenario input known to the client, keyed by a stable synthetic
+  scenario name rather than transport metadata; and
+- application-visible outputs, state changes, and invalidations produced for the scenario.
+
+Two clients have equivalent canonical protocol state when every applicable field above is equal. Full scenario
+quiescence additionally requires that neither client has an unresolved convergence pass or required publication.
+
+Local queue layout, transport cursors, retry counters, database row ids, storage encoding, pruned secrets, and private
+ratchet state are not part of canonical protocol-state equality. A test MAY compare those as separate availability,
+resource, or implementation assertions.
+
+This projection is a conformance-test interface. It defines no wire message, group extension, or interoperable
+serialization.
+
+## Exporter commitment
+
+The conformance exporter secret is:
+
+```text
+MLS-Exporter("marmot", "convergence-conformance-v1", 32)
+```
+
+The snapshot contains only this commitment:
+
+```text
+SHA256(
+  "marmot-convergence-conformance-v1" ||
+  0x00 ||
+  conformance_exporter_secret
+)
+```
+
+The domain string before `0x00` is exactly 33 ASCII bytes. The raw exporter secret MUST NOT appear in logs, reports, or
+test artifacts. The commitment is limited to synthetic conformance tests and local forensic comparison; production
+telemetry MUST NOT export it.

--- a/foundation/errors.md
+++ b/foundation/errors.md
@@ -20,6 +20,10 @@ An input that does not produce application content SHOULD map to one of these ca
 - `unsupported_required_feature`: the group requires a feature the client does not understand.
 - `authorization_failed`: the sender or committer is not allowed to make the change.
 - `missing_history`: the client would need retained state it no longer has.
+- `transport_deferred`: the transport object cannot currently be decoded or decrypted, but a later transport
+  decryption context could make it recoverable.
+- `resource_refused`: a local resource bound prevented the client from retaining or processing an otherwise
+  unclassified transport object.
 - `transport_rejected`: an outbound publication or delivery attempt failed at the transport layer. This category does
   not describe inbound bytes that were never received.
 
@@ -62,9 +66,15 @@ branch-independent gate. A retained state that does not authenticate the Commit 
 If no retained state passes parent-dependent MLS authentication, the Commit remains deferred while its source epoch is
 inside or ahead of the rollback horizon. Once authentication identifies the candidate parent, failed authorization is
 terminal `authorization_failed` and receives no convergence disposition.
-`transport_rejected` is an outbound transport outcome, not an inbound or convergence disposition. Every received
-inbound input therefore has exactly one current outcome: a convergence disposition when convergence classifies it,
-otherwise an inbound rejection category. A convergence disposition is a live classification, not an immutable
+`transport_deferred` and `resource_refused` are pre-convergence availability categories, not convergence dispositions.
+They describe a transport object whose inner Marmot protocol input has not yet been recovered or admitted. A client
+MUST NOT label such an object `stale`, `invalid_encoding`, or a terminal `duplicate` merely because its current
+decryption context or local resource budget was insufficient.
+
+`transport_rejected` is an outbound transport outcome, not an inbound or convergence disposition. Every recovered
+inbound protocol input therefore has exactly one current outcome: a convergence disposition when convergence
+classifies it, otherwise an inbound rejection category. A transport object that has not yielded protocol input has one
+current availability category instead. A convergence disposition is a live classification, not an immutable
 processing-history label. It MAY change when missing state arrives or a later pass selects a different canonical
 branch; at every point the input still has only one current disposition.
 
@@ -74,6 +84,10 @@ document said an input was dropped, this vocabulary says `stale`.
 
 A disposition says what happened to an input. The categories above say why. A `stale` or `deferred` input SHOULD carry
 a category, such as `duplicate` or `stale_epoch`.
+
+`resource_refused` is also the stable category when a client abandons retained transport work after reaching a local
+retry or storage threshold. The same transport object remains eligible if it is delivered or fetched again; the
+threshold does not prove that the object is permanently unreadable.
 
 ## Named convergence outcomes
 

--- a/foundation/registries.md
+++ b/foundation/registries.md
@@ -166,12 +166,13 @@ is the `context`, and the third is the output length in bytes.
 The `label` and `context` pair is the top-level domain separator. Owning documents define any additional key context
 used below the exporter output.
 
-| Label      | Context                    | Length   | Consumer                              |
-| ---------- | -------------------------- | -------- | ------------------------------------- |
-| `"marmot"` | `"group-event"`            | `32`     | kind `445` outer encryption key       |
-| `"marmot"` | `"encrypted-media"`        | `32`     | encrypted-media per-file key schedule |
-| `"marmot"` | `"agent-text-stream-quic"` | `32`     | agent text stream QUIC record crypto  |
-| `"marmot"` | `join_psk_id`              | `KDF.Nh` | multi-device external PSK material    |
+| Label      | Context                        | Length   | Consumer                               |
+| ---------- | ------------------------------ | -------- | -------------------------------------- |
+| `"marmot"` | `"group-event"`                | `32`     | kind `445` outer encryption key        |
+| `"marmot"` | `"encrypted-media"`            | `32`     | encrypted-media per-file key schedule  |
+| `"marmot"` | `"agent-text-stream-quic"`     | `32`     | agent text stream QUIC record crypto   |
+| `"marmot"` | `"convergence-conformance-v1"` | `32`     | synthetic conformance state commitment |
+| `"marmot"` | `join_psk_id`                  | `KDF.Nh` | multi-device external PSK material     |
 
 Fixed `32`-byte outputs are used where the owning document feeds a 32-byte AEAD key or feature key schedule.
 `KDF.Nh` is used for the multi-device join PSK because that output is external PSK material for the MLS ciphersuite KDF.

--- a/layout.md
+++ b/layout.md
@@ -25,6 +25,7 @@ foundation/
   application-messages.md
   wire-envelopes.md
   mls-protocol.md
+  conformance.md
   errors.md
   registries.md
 protocol-core/
@@ -80,6 +81,7 @@ Foundation documents define shared surfaces:
 - app payload shape
 - wire envelopes
 - MLS protocol choices
+- canonical protocol-state equivalence for conformance testing
 - error and stale-result taxonomy
 - registries for component ids, proposal ids, and extension ids
 

--- a/protocol-core/convergence.md
+++ b/protocol-core/convergence.md
@@ -7,6 +7,31 @@ Convergence chooses one canonical branch from unordered group input.
 Commits are the consensus log. MLS application messages can witness that members used a branch, but they do not create
 epochs and they do not replace MLS commit validation.
 
+## Guarantees and assumptions
+
+Convergence has separate safety and liveness guarantees.
+
+For safety, clients that start from the same retained anchor, use the same convergence policy, and resolve the same
+frozen authenticated input batch with the same retained dependencies MUST select the same canonical branch and assign
+the same convergence dispositions. Transport arrival order, local scheduling, and device speed do not weaken this
+requirement.
+
+For liveness across more than one pass, the relevant input must eventually close. Relevant input is closed for a group
+when there is a finite set of valid selection-relevant input and authenticated dependencies, no later valid input can
+extend or change that set, and every compared client has acquired the same set while it remains inside the applicable
+retention and rollback horizons. Given that closure, clients using the same convergence policy that continue executing,
+retain the required state, revisit deferred work, and have sufficient local resources MUST eventually reach equivalent
+canonical protocol state as defined in
+[../foundation/conformance.md](../foundation/conformance.md).
+
+This liveness guarantee does not apply during permanent delivery suppression, an unbounded stream of valid
+selection-relevant input, loss beyond the retained-history limits, incompatible convergence policies, or local resource
+exhaustion. A client affected by one of those conditions still follows the fail-closed safety rules below.
+
+`Settled` is a local fixed point over the protocol input currently retained and admitted by that client. It is not
+global finality, proof that every transport has finished synchronization, or a promise that later valid input cannot
+open another pass.
+
 ## Convergence policy
 
 The convergence policy tells clients how to run convergence. The v1 convergence policy is a set of protocol constants:
@@ -94,6 +119,11 @@ as required below. Input retained after the cutoff is not discarded; it belongs 
 controls scheduling and batch membership only. Input arrival time, cutoff time, and pass membership MUST NOT enter
 candidate validity or the branch score.
 
+After relevant input closes under the assumptions above, dividing that same retained input across different bounded
+passes MUST NOT change the eventual canonical result. Input excluded by one cutoff remains eligible for a later pass
+until the protocol assigns it a terminal disposition. Implementations MUST NOT use timer tuning or pass partitioning to
+resolve a difference that the deterministic selection rules leave open.
+
 After a bounded pass settles in `Stable`, the client MUST give one already-queued, admin-authorized local group-state
 intent one preparation attempt against the selected canonical state before it begins another convergence pass solely
 because more inbound input is queued. Inbound input remains durably retained during that attempt. If the attempt cannot
@@ -101,9 +131,15 @@ proceed with currently available authorization, prerequisites, or signing capabi
 than waiting indefinitely. A prepared Commit then follows the normal publication and convergence rules; this scheduling
 guarantee does not make it valid, accepted, or canonical.
 
+The preparation opportunity is bounded anti-starvation behavior, not an unconditional administrative-progress
+guarantee. Marmot does not guarantee that a privileged transition becomes canonical while valid selection-relevant
+input, including ordinary self-updates, continues without bound.
+
 Convergence parameters are deliberately not group-tunable: a bad policy choice can fork a group. A future protocol
 version that changes convergence behavior MUST ship the new policy as a new app component behind a required capability.
-Until such a component exists, there is no mechanism to change the active policy.
+This includes changes to eligibility, retention horizons, comparison order, witness scoring, admissible input, or any
+other rule that can change the selected branch. Clients MUST NOT infer the active policy from software version. Until
+such a component exists, there is no mechanism to change the active policy.
 
 ## Fork detection
 

--- a/protocol-core/group-state.md
+++ b/protocol-core/group-state.md
@@ -141,25 +141,30 @@ Convergence has a separate derived status:
   retained in that batch. It does not wait for fetches or admit later input; unresolved children remain deferred to a
   later pass.
 - `Settled`: candidate processing reached a fixed point and the selected branch, if any, has been applied.
-- `Blocked`: candidate processing cannot safely continue without a repair path or missing retained material.
+- `Blocked`: candidate processing cannot safely continue without a repair path, missing retained material, or sufficient
+  local resources to finish the immutable admitted batch.
 
 Convergence status is derived from stored input and policy. It is not a claim made by the transport.
+`Settled` is therefore local to the input retained and admitted by the client. Transport synchronization is a separate
+availability condition and MUST NOT be inferred from `Settled`.
 
 The lifecycle state is authoritative; convergence status is a derived view of how convergence is progressing within it.
 The legal combinations are:
 
-| Convergence status | Lifecycle states it can appear in | Notes                                                                 |
-| ------------------ | --------------------------------- | --------------------------------------------------------------------- |
-| `Syncing`          | `Stable`, `Recovering`            | bounded pass still collecting selection-relevant input                |
-| `Resolving`        | `Stable`, `Recovering`            | frozen-batch fixed-point work; no waiting or new input                |
-| `Settled`          | `Stable`, `Disbanded`             | fixed point reached and any selected branch applied                   |
-| `Blocked`          | `Recovering`, `Unrecoverable`     | needs a repair path or missing retained material                      |
+| Convergence status | Lifecycle states it can appear in       | Notes                                                          |
+| ------------------ | --------------------------------------- | -------------------------------------------------------------- |
+| `Syncing`          | `Stable`, `Recovering`                  | bounded pass still collecting selection-relevant input         |
+| `Resolving`        | `Stable`, `Recovering`                  | frozen-batch fixed-point work; no waiting or new input         |
+| `Settled`          | `Stable`, `Disbanded`                   | fixed point reached and any selected branch applied            |
+| `Blocked`          | `Stable`, `Recovering`, `Unrecoverable` | needs retained material, a repair path, or local resources     |
 
 Two couplings follow from this table. A group leaves `Recovering` for `Stable` only after convergence reaches
-`Settled` (a selected branch was applied). A `Blocked` convergence status that cannot be cleared by retained material
-is the `Unrecoverable` condition: when recovery has no safe branch and no repair path, the lifecycle moves to
-`Unrecoverable`. `PendingPublish` and `Merging` are local-publish states, not convergence passes, so convergence status
-is not meaningful while the group is in them.
+`Settled` (a selected branch was applied). A resource-caused `Blocked` status does not by itself change the lifecycle:
+the immutable admitted batch remains unapplied and processing resumes when sufficient resources become available. Only
+a `Blocked` status caused by required retained state that is permanently missing or corrupt is the `Unrecoverable`
+condition: when recovery has no safe branch and no repair path, the lifecycle moves to `Unrecoverable`.
+`PendingPublish` and `Merging` are local-publish states, not convergence passes, so convergence status is not meaningful
+while the group is in them.
 
 A disband Commit is the exception to ordinary linear advancement. When a valid
 disband candidate is admitted from `Stable`, the client enters `Recovering`

--- a/protocol-core/inbound-processing.md
+++ b/protocol-core/inbound-processing.md
@@ -61,10 +61,26 @@ terminal-rejection rules are defined in [convergence.md](./convergence.md), "Can
 Input naming a group for which the client has no processable group state receives the `unknown_group` category before
 convergence and no convergence disposition. The client cannot authenticate or classify a branch without that state.
 
+## Transport-deferred input
+
+A received transport object is not yet Marmot protocol input when the client cannot recover its inner MLS bytes with
+the currently available transport decryption keys. When a later canonical epoch, retained candidate state, staged
+state, or verified repair could make the object decryptable, the current category is `transport_deferred`, not
+`stale_epoch` or `invalid_encoding`, and the object receives no convergence disposition.
+
+The active transport binding defines how a client retains, retries, refetches, or backfills such an object. A retained
+object MUST be retried whenever the transport decryption context changes in a way that could change the result.
+Implementations MAY suppress retries while that context is unchanged.
+
+A client MAY refuse to retain an unclassified transport object under a local resource bound. That outcome is
+`resource_refused`: it makes no claim that the object is invalid or permanently unreadable. A refused object MUST NOT
+be recorded as a terminal duplicate, and the client MUST NOT claim that the affected transport history is synchronized
+until the binding's recovery rule has given the object another delivery opportunity.
+
 ## Deferred input
 
-A client MAY defer an input when it cannot yet be processed but could become processable after more protocol bytes
-arrive.
+A client MAY defer recovered Marmot protocol input when it cannot yet be processed but could become processable after
+more protocol bytes arrive.
 
 Common deferred cases:
 

--- a/protocol-core/retained-history.md
+++ b/protocol-core/retained-history.md
@@ -77,6 +77,11 @@ An MLS application message outside the retained app-payload window MUST expire (
 An MLS application message for a future candidate epoch MAY remain deferred until convergence selects a branch that can
 decrypt its Marmot app payload or until the message expires.
 
+The retained app-payload window is not a complete offline-message-history guarantee. A client that returns after more
+than `app_payload_past_epoch_limit` canonical epoch advances can conformantly lose application payloads from older
+epochs even when their transport objects remain available. Applications that require complete long-term history need a
+separate protocol mechanism; transport retention alone does not extend the MLS decryption window.
+
 ## Pruning
 
 After convergence reaches a settled selected branch, a client SHOULD prune retained states older than the group's

--- a/transports/nostr.md
+++ b/transports/nostr.md
@@ -156,8 +156,20 @@ with the rule in [../protocol-core/group-state.md](../protocol-core/group-state.
 `PendingPublish` or `Merging`: trial decryption only recovers bytes for convergence to judge, and the inbound message is
 not applied while the group is in those states.
 
-If no retained candidate key authenticates the content, the event is undecryptable transport input and is retained or
-dropped under the inbound-processing rules, not applied to group state.
+If no retained candidate key authenticates the content, the event is undecryptable transport input and is not applied
+to group state. A retained event has the `transport_deferred` availability category. The client MUST retry it after a
+canonical epoch change, retained-candidate change, staged-state change, or verified repair changes the candidate key
+set; it MAY suppress repeated attempts while that set is unchanged.
+
+If a local resource limit prevents retention or retires the event after a bounded number of attempts, the event has
+the `resource_refused` availability category. The client MUST NOT record that event id as terminally seen or
+permanently unreadable, and the same event id remains eligible when later delivered or fetched.
+
+A subscription or backfill range containing a resource-refused event is not synchronized merely because the relay
+reported end-of-stored-events or the client advanced a local cursor. After capacity becomes available, the client MUST
+give the refused event another delivery opportunity by refetching an overlapping range or by an equivalent
+transport-specific recovery mechanism. Deferred or refused events MUST NOT block unrelated valid input from being
+processed and MUST NOT choose canonical group state.
 
 The public routing id and required fresh ephemeral event key do not provide a member-authenticated prefilter for kind
 `445`; a non-member can submit envelopes that reach trial decryption. Relay admission controls and client-side input,


### PR DESCRIPTION
## What

- define separate convergence safety and conditional-liveness guarantees, including pass-partition invariance and the limits of fair scheduling
- define a canonical protocol-state projection and domain-separated exporter commitment for deterministic cross-client conformance tests
- distinguish transport-deferred and resource-refused objects from stale, invalid, or terminally deduplicated protocol input
- require context-triggered retry and a renewed delivery opportunity after resource refusal
- clarify that local convergence settlement is not transport synchronization and that retained MLS history does not guarantee complete offline application-message history
- require an explicit protocol capability/component when state-selecting convergence policy changes

## Why

The convergence simulator needs a protocol-owned oracle and precise failure vocabulary before it can serve as a black-box engine test. In particular, an object that cannot be peeled with the current epoch keys may become readable after another commit advances the client, while exhausting a local retry or storage budget says nothing about the object's validity. Treating either case as stale or permanently seen can silently strand valid work.

The liveness text also makes the operating envelope explicit: deterministic convergence is guaranteed after relevant valid input closes and clients acquire the same retained dependencies, not under permanent delivery suppression, resource exhaustion, incompatible policies, or an infinite stream of valid self-updates.

## Impact

This intentionally changes normative behavior for Nostr clients that currently terminally discard or deduplicate deferred objects when local retry/storage limits are reached. Implementations need an availability outcome that remains refetch-eligible and must not claim the affected range is synchronized until another delivery opportunity occurs.

The conformance snapshot is test-only. It defines no wire encoding and forbids logging or production telemetry of the raw exporter secret.

## Verification

- reviewed all repository boundary/leak grep matches required by `AGENTS.md`
- verified all changed Markdown links resolve locally
- verified the exporter commitment domain is exactly 33 ASCII bytes
- `git diff --check`