### PR TITLE
Specify durability and restart contract

### DIFF
--- a/foundation/README.md
+++ b/foundation/README.md
@@ -18,7 +18,8 @@ Foundation docs SHOULD change slowly. A change here usually means the whole prot
 - [application-messages.md](./application-messages.md) - the unsigned Nostr-shaped payload inside MLS messages.
 - [wire-envelopes.md](./wire-envelopes.md) - the split between application payloads, MLS bytes, and transport envelopes.
 - [mls-protocol.md](./mls-protocol.md) - the MLS protocol pieces Marmot builds on.
-- [conformance.md](./conformance.md) - canonical protocol-state equivalence for deterministic testing.
+- [conformance.md](./conformance.md) - canonical protocol-state equivalence and crash/restart scenarios for
+  deterministic testing.
 - [errors.md](./errors.md) - shared result and rejection vocabulary.
 - [registries.md](./registries.md) - Marmot-owned ids and namespaces.
 

--- a/foundation/conformance.md
+++ b/foundation/conformance.md
@@ -20,12 +20,15 @@ A conformance snapshot for one group contains:
   component value bytes;
 - the canonical group lifecycle and current convergence status;
 - every local protocol gate or terminal local condition that restricts legal group actions;
-- the protocol-relevant meaning of every unresolved required publication: exact outbound bytes and recipient scope,
-  plus the conformance projections of its prior and pending group states from
+- the protocol-relevant meaning of every unresolved required publication: exact outbound bytes, recipient scope,
+  whether an external publish attempt may have occurred, whether the required acknowledgement is known to have
+  succeeded, and the conformance projections of its prior and pending group states from
   [../protocol-core/publish-lifecycle.md](../protocol-core/publish-lifecycle.md);
 - the current convergence disposition of every scenario input known to the client, keyed by a stable synthetic
   scenario name rather than transport metadata; and
-- application-visible outputs, state changes, and invalidations produced for the scenario.
+- application-visible outputs, state changes, and invalidations produced for the scenario, keyed by their stable
+  effect identities, including whether each effect's observation boundary is established under
+  [../protocol-core/durability.md](../protocol-core/durability.md) ("Application effects after restart").
 
 Two clients have equivalent canonical protocol state when every applicable field above is equal. Full scenario
 quiescence additionally requires that neither client has an unresolved convergence pass or required publication.
@@ -54,8 +57,10 @@ equal the reference snapshot. Conformance tests for this contract MUST cover at 
    Recovery produces exactly the confirmed resulting state and does not expose a mixed epoch, component, disposition,
    or output projection.
 4. **Applied, derived work incomplete:** interrupt after canonical state changes but before each disposition,
-   notification, delivery, withdrawal, or invalidation is observed. Recovery preserves one effective output per stable
-   input identity or `commit_digest` and completes every required inverse effect.
+   notification, delivery, withdrawal, or invalidation crosses its observation boundary. Recovery re-emits each
+   unobserved effect with its stable effect identity or re-exposes an equivalent reconstructible projection, preserves
+   one effective output per identity, and completes every required inverse effect. Repeat after an acknowledgement or
+   equivalent projection has established observation and verify that restart does not create a second effective output.
 5. **Collecting:** interrupt with eligible admitted input collected and more input retained near each timer boundary.
    Resetting local timers or changing pass partitioning may delay settlement but, after relevant input closes, produces
    the same canonical snapshot and dispositions as uninterrupted execution.
@@ -66,9 +71,10 @@ equal the reference snapshot. Conformance tests for this contract MUST cover at 
    supersedes previously delivered payloads or state notifications and a branch that disbands the group. Recovery
    exposes either the complete prior projection or the complete selected projection, never a mixture.
 8. **Missing or corrupt material:** remove one selection-relevant candidate parent, admitted input, frozen dependency,
-   or acknowledgement-uncertain pending transition inside its active horizon. If exact reconstruction is impossible,
-   recovery enters `Unrecoverable`, leaves any associated admitted input deferred with `missing_history`, and does not
-   select the only remaining local branch.
+   or acknowledgement-uncertain pending transition inside its active horizon. If exact reconstruction is permanently
+   impossible and no verified repair path is available, recovery enters `Unrecoverable`, leaves any associated admitted
+   input deferred with `missing_history`, and does not select the only remaining local branch. Temporary unavailability
+   instead blocks the affected work without changing the lifecycle solely for that reason.
 9. **Local gates and terminal effects:** interrupt while `Leaving` or `Disbanding`, while realizing local-leaf removal,
    and while terminalizing disband. Recovery preserves the outbound gate and reconstructs the required effective
    notification or tombstone without a duplicate presentation effect.

--- a/foundation/conformance.md
+++ b/foundation/conformance.md
@@ -19,6 +19,10 @@ A conformance snapshot for one group contains:
 - every `GroupContext.extensions.app_data_dictionary` entry in ascending component-id order, including the exact
   component value bytes;
 - the canonical group lifecycle and current convergence status;
+- every local protocol gate or terminal local condition that restricts legal group actions;
+- the protocol-relevant meaning of every unresolved required publication: exact outbound bytes and recipient scope,
+  plus the conformance projections of its prior and pending group states from
+  [../protocol-core/publish-lifecycle.md](../protocol-core/publish-lifecycle.md);
 - the current convergence disposition of every scenario input known to the client, keyed by a stable synthetic
   scenario name rather than transport metadata; and
 - application-visible outputs, state changes, and invalidations produced for the scenario.
@@ -32,6 +36,46 @@ resource, or implementation assertions.
 
 This projection is a conformance-test interface. It defines no wire message, group extension, or interoperable
 serialization.
+
+## Crash and restart scenarios
+
+Durability conformance compares a restarted client with an uninterrupted reference given the same subsequent local
+actions and transport outcomes, at complete observer boundaries. The restarted client MAY expose a longer
+`PendingPublish`, `Merging`, `Recovering`, or `Blocked` interval, but after required work completes its snapshot MUST
+equal the reference snapshot. Conformance tests for this contract MUST cover at least these boundaries:
+
+1. **Prepared, not published:** interrupt after preparation but before any external attempt. Recovery either abandons
+   the preparation with the prior canonical state intact or retries the same obligation; pending state is never
+   canonical before acknowledgement.
+2. **Acknowledgement uncertain:** externally accept the bytes, interrupt before the acknowledgement is recoverable,
+   and redeliver or retry. Recovery keeps one unresolved obligation, never generates replacement Commit bytes, and
+   reaches one effective application of the original Commit after a conforming acknowledgement.
+3. **Confirmed, not applied:** interrupt after confirmation and at several points during canonical application.
+   Recovery produces exactly the confirmed resulting state and does not expose a mixed epoch, component, disposition,
+   or output projection.
+4. **Applied, derived work incomplete:** interrupt after canonical state changes but before each disposition,
+   notification, delivery, withdrawal, or invalidation is observed. Recovery preserves one effective output per stable
+   input identity or `commit_digest` and completes every required inverse effect.
+5. **Collecting:** interrupt with eligible admitted input collected and more input retained near each timer boundary.
+   Resetting local timers or changing pass partitioning may delay settlement but, after relevant input closes, produces
+   the same canonical snapshot and dispositions as uninterrupted execution.
+6. **Frozen resolving batch:** interrupt while fixed-point work is incomplete. Recovery either resolves the identical
+   batch or wholly recollects its still-eligible input; it never selects from an accidental subset or admits later
+   input into the old frozen batch.
+7. **Selected branch applying:** interrupt after selection at each multi-part apply boundary, including a branch that
+   supersedes previously delivered payloads or state notifications and a branch that disbands the group. Recovery
+   exposes either the complete prior projection or the complete selected projection, never a mixture.
+8. **Missing or corrupt material:** remove one selection-relevant candidate parent, admitted input, frozen dependency,
+   or acknowledgement-uncertain pending transition inside its active horizon. If exact reconstruction is impossible,
+   recovery enters `Unrecoverable`, leaves any associated admitted input deferred with `missing_history`, and does not
+   select the only remaining local branch.
+9. **Local gates and terminal effects:** interrupt while `Leaving` or `Disbanding`, while realizing local-leaf removal,
+   and while terminalizing disband. Recovery preserves the outbound gate and reconstructs the required effective
+   notification or tombstone without a duplicate presentation effect.
+
+These tests compare behavior and the projection above. They MUST NOT require a database schema, transaction API,
+snapshot encoding, process scheduler, or one snapshot per epoch. The owning normative rules are in
+[../protocol-core/durability.md](../protocol-core/durability.md).
 
 ## Exporter commitment
 

--- a/foundation/errors.md
+++ b/foundation/errors.md
@@ -113,6 +113,12 @@ Protocol rejections are part of interop. Local failures are not.
 For example, `invalid_encoding` is a protocol rejection. A database write failure is a local implementation failure. A
 transport publish failure matters to publish-before-apply, but the exact retry queue or error object is local.
 
+Loss or corruption of required retained material is also a local cause with a protocol-visible fail-closed result. It
+does not permit a client to guess a branch or terminally reclassify affected input. The restart contract in
+[../protocol-core/durability.md](../protocol-core/durability.md) defines when the group becomes `Unrecoverable`; an
+associated admitted input remains `deferred` with `missing_history` until a verified repair or ordinary retention rule
+permits another outcome.
+
 ## Privacy
 
 Diagnostics for these outcomes MUST avoid account ids, group ids, message ids, relay URLs, pubkeys, payloads,

--- a/implementation-model.md
+++ b/implementation-model.md
@@ -48,6 +48,21 @@ means storing raw MLS message bytes, welcome bytes, prior state snapshots, and l
 
 The protocol defines what must be reproducible. It does not define table names, cache keys, or snapshot formats.
 
+## Durability Boundary
+
+The normative restart contract is [protocol-core/durability.md](./protocol-core/durability.md). An implementation may
+satisfy it with transactions, journals, snapshots, replay, derived indexes, or another strategy. It need not keep one
+physical snapshot per epoch, and protocol-state atomicity does not require one physical write.
+
+The useful design boundary is logical: before outbound bytes can escape, their exact publish obligation and recovery
+states are reproducible; before a selected branch is exposed, canonical state, dispositions, gates, and application
+effects form one complete observer projection. Restart recovery can resume work or replay deterministic work from a
+verified boundary. It cannot invent a success, silently omit admitted input, or expose a mixed projection.
+
+Local application delivery APIs may use acknowledgements, cursors, an effective-state query, or idempotent callbacks.
+Those shapes are implementation-defined. They need to preserve the protocol requirement that restart neither loses a
+required effect nor creates a second effective delivery.
+
 ## Convergence Policy Overrides
 
 The normative pinned-policy rule lives in [protocol-core/convergence.md](./protocol-core/convergence.md) ("Convergence

--- a/layout.md
+++ b/layout.md
@@ -39,6 +39,7 @@ protocol-core/
   inbound-processing.md
   convergence.md
   retained-history.md
+  durability.md
 app-components/
   README.md
   group-profile-v1.md
@@ -81,7 +82,7 @@ Foundation documents define shared surfaces:
 - app payload shape
 - wire envelopes
 - MLS protocol choices
-- canonical protocol-state equivalence for conformance testing
+- canonical protocol-state equivalence, including crash/restart conformance testing
 - error and stale-result taxonomy
 - registries for component ids, proposal ids, and extension ids
 

--- a/principles.md
+++ b/principles.md
@@ -82,6 +82,11 @@ helpers, or logging implementations. Those belong in `implementation-model.md`, 
 It is fine for a protocol doc to say that a client MUST retain enough material to reproduce a decision. It SHOULD NOT
 say which table stores that material.
 
+Process restart does not make a state transition local-only when peers or the application can observe its effects.
+Protocol text SHOULD name the facts and outcomes that MUST remain reproducible, the safe retry boundary, and which
+multi-part changes MUST NOT be exposed partially. It SHOULD use capability language such as "retain or be able to
+reconstruct" and leave physical persistence, transaction, and snapshot strategies implementation-defined.
+
 ## Keep identity, delivery addressing, and transport separate
 
 Identity says who an account or member is.

--- a/protocol-core/AGENTS.md
+++ b/protocol-core/AGENTS.md
@@ -7,13 +7,13 @@ cross-surface map is in [`../AGENTS.md`](../AGENTS.md).
 
 Protocol-core owns the required group flows and group-state transitions every transport and feature relies on: group
 setup, joining, messaging, member departure, the group-state lifecycle, publish-before-apply, inbound processing,
-convergence, and retained history. It says *when* MLS-valid bytes become canonical group state.
+convergence, retained history, and restart behavior. It says *when* MLS-valid bytes become canonical group state.
 
 ## Read order
 
 1. [`README.md`](README.md) (big picture + main flows), then [`group-state.md`](group-state.md).
 2. The convergence spine: [`convergence.md`](convergence.md), [`publish-lifecycle.md`](publish-lifecycle.md),
-   [`retained-history.md`](retained-history.md).
+   [`retained-history.md`](retained-history.md), [`durability.md`](durability.md).
 3. The specific flow doc you are editing.
 
 ## Rules

--- a/protocol-core/README.md
+++ b/protocol-core/README.md
@@ -72,6 +72,7 @@ find compatible KeyPackage
 - [inbound-processing.md](./inbound-processing.md) - how incoming bytes are stored, classified, and retried.
 - [convergence.md](./convergence.md) - how candidate branches are built, scored, selected, and applied.
 - [retained-history.md](./retained-history.md) - retained state, rollback horizon, and late input rules.
+- [durability.md](./durability.md) - recoverable protocol facts, crash boundaries, and restart equivalence.
 
 ## Core rule
 

--- a/protocol-core/convergence.md
+++ b/protocol-core/convergence.md
@@ -32,8 +32,10 @@ exhaustion. A client affected by one of those conditions still follows the fail-
 global finality, proof that every transport has finished synchronization, or a promise that later valid input cannot
 open another pass.
 
-Process interruption does not weaken these guarantees. The recoverable-input, pass-restart, and observer-atomic apply
-rules are defined in [durability.md](./durability.md) ("Restart equivalence" and "Convergence interruption
+Process interruption does not weaken the safety guarantee. After interruption, liveness applies only after the client
+has recovered the required authenticated inputs and dependencies and resumed execution, with the same input-closure,
+retention, convergence-policy, and resource conditions above. The recoverable-input, pass-restart, and observer-atomic
+apply rules are defined in [durability.md](./durability.md) ("Restart equivalence" and "Convergence interruption
 boundaries").
 
 ## Convergence policy
@@ -114,14 +116,19 @@ parent does not keep this pass open.
 
 Fixed-point resolution is not subject to a protocol wall-clock deadline: device speed MUST NOT make clients resolve the
 same frozen batch differently. An implementation MAY yield and resume the work locally, but it MUST complete
-deterministic resolution of that immutable batch before starting another pass.
+deterministic resolution of that immutable batch before starting another pass. The only exception is process
+interruption under [durability.md](./durability.md) ("Convergence interruption boundaries"): a wholly unapplied frozen
+batch MAY instead be abandoned, after which every still-eligible input and authenticated dependency from that batch is
+admitted to a later pass. This exception MUST NOT discard an input, resolve an accidental subset, or apply any result
+from the abandoned batch.
 
 A recovering client returns to `Stable` only after successfully selecting and applying the canonical branch. A linear
 pass that began in `Stable` remains `Stable` after applying its selected advancement. If required retained state,
-including the retained anchor, is missing, the client does not mutate canonical group state and enters `Unrecoverable`
-as required below. Input retained after the cutoff is not discarded; it belongs to a later pass. The local cutoff
-controls scheduling and batch membership only. Input arrival time, cutoff time, and pass membership MUST NOT enter
-candidate validity or the branch score.
+including the retained anchor, is permanently missing or corrupt and no verified repair path is available, the client
+does not mutate canonical group state and enters `Unrecoverable` as required below. Temporary unavailability instead
+leaves the immutable work unapplied and `Blocked`. Input retained after the cutoff is not discarded; it belongs to a
+later pass. The local cutoff controls scheduling and batch membership only. Input arrival time, cutoff time, and pass
+membership MUST NOT enter candidate validity or the branch score.
 
 After relevant input closes under the assumptions above, dividing that same retained input across different bounded
 passes MUST NOT change the eventual canonical result. Input excluded by one cutoff remains eligible for a later pass
@@ -360,14 +367,13 @@ key.
 
 ## Applying the selected branch
 
-After selecting a branch, a client applies the selected branch by replaying the selected commit path from the retained
-parent state.
+After selecting a branch, a client tentatively replays the selected commit path from the retained parent state to
+compute the resulting canonical state. Before exposing any result of that replay, it MUST compute the selected
+branch's canonical state, dispositions, protocol gates or terminal conditions, and application effects. The client
+then exposes those fields as one complete observer projection. Interrupted application follows
+[durability.md](./durability.md) ("Observer-atomic transitions") and MUST NOT expose a partially applied branch.
 
-Canonical state, dispositions, gates, and application effects produced by this application MUST form one complete
-observer projection. Interrupted application follows [durability.md](./durability.md) ("Observer-atomic transitions")
-and MUST NOT expose a partially applied branch.
-
-The client then assigns dispositions (the disposition vocabulary is pinned in
+As part of computing that projection, the client assigns dispositions (the disposition vocabulary is pinned in
 [../foundation/errors.md](../foundation/errors.md)):
 
 - commits on the selected path are accepted;
@@ -409,9 +415,10 @@ requirement is the resulting view. Once convergence is settled, the state notifi
 those derivable from the accepted commits on the selected branch, and a group-state change that lost branch selection
 MUST NOT remain visible to the application as a completed change.
 
-If the required retained state is missing, the client MUST report the missing retained anchor and MUST NOT mutate
-canonical group state. If the missing state is inside the rollback horizon, the client enters `Unrecoverable` until it
-has a verified repair path.
+If required retained state is unavailable, the client MUST report the missing retained anchor and MUST NOT mutate
+canonical group state. Temporary unavailability leaves convergence `Blocked`. If the state is inside the rollback
+horizon, is permanently missing or corrupt, and no verified repair path is available, the client enters
+`Unrecoverable`.
 
 After applying the selected branch, retained-state release follows
 [retained-history.md](./retained-history.md) ("Pruning"); that document owns the pruning obligation and its exceptions.

--- a/protocol-core/convergence.md
+++ b/protocol-core/convergence.md
@@ -32,6 +32,10 @@ exhaustion. A client affected by one of those conditions still follows the fail-
 global finality, proof that every transport has finished synchronization, or a promise that later valid input cannot
 open another pass.
 
+Process interruption does not weaken these guarantees. The recoverable-input, pass-restart, and observer-atomic apply
+rules are defined in [durability.md](./durability.md) ("Restart equivalence" and "Convergence interruption
+boundaries").
+
 ## Convergence policy
 
 The convergence policy tells clients how to run convergence. The v1 convergence policy is a set of protocol constants:
@@ -358,6 +362,10 @@ key.
 
 After selecting a branch, a client applies the selected branch by replaying the selected commit path from the retained
 parent state.
+
+Canonical state, dispositions, gates, and application effects produced by this application MUST form one complete
+observer projection. Interrupted application follows [durability.md](./durability.md) ("Observer-atomic transitions")
+and MUST NOT expose a partially applied branch.
 
 The client then assigns dispositions (the disposition vocabulary is pinned in
 [../foundation/errors.md](../foundation/errors.md)):

--- a/protocol-core/convergence.md
+++ b/protocol-core/convergence.md
@@ -122,13 +122,15 @@ batch MAY instead be abandoned, after which every still-eligible input and authe
 admitted to a later pass. This exception MUST NOT discard an input, resolve an accidental subset, or apply any result
 from the abandoned batch.
 
-A recovering client returns to `Stable` only after successfully selecting and applying the canonical branch. A linear
-pass that began in `Stable` remains `Stable` after applying its selected advancement. If required retained state,
-including the retained anchor, is permanently missing or corrupt and no verified repair path is available, the client
-does not mutate canonical group state and enters `Unrecoverable` as required below. Temporary unavailability instead
-leaves the immutable work unapplied and `Blocked`. Input retained after the cutoff is not discarded; it belongs to a
-later pass. The local cutoff controls scheduling and batch membership only. Input arrival time, cutoff time, and pass
-membership MUST NOT enter candidate validity or the branch score.
+A recovering client returns to `Stable` only after successfully selecting and applying a non-terminal canonical
+branch. If the selected branch ends in `disbanded`, recovery instead enters the terminal `Disbanded` state, releases
+live MLS and convergence state, and does not allow a later branch to supersede it, as defined in "Applying the selected
+branch." A linear pass that began in `Stable` remains `Stable` after applying its selected advancement. If required
+retained state, including the retained anchor, is permanently missing or corrupt and no verified repair path is
+available, the client does not mutate canonical group state and enters `Unrecoverable` as required below. Temporary
+unavailability instead leaves the immutable work unapplied and `Blocked`. Input retained after the cutoff is not
+discarded; it belongs to a later pass. The local cutoff controls scheduling and batch membership only. Input arrival
+time, cutoff time, and pass membership MUST NOT enter candidate validity or the branch score.
 
 After relevant input closes under the assumptions above, dividing that same retained input across different bounded
 passes MUST NOT change the eventual canonical result. Input excluded by one cutoff remains eligible for a later pass

--- a/protocol-core/durability.md
+++ b/protocol-core/durability.md
@@ -1,0 +1,168 @@
+# Durability and restart
+
+Status: adopted.
+
+This document defines the implementation-neutral durability contract for Marmot group processing. It specifies which
+protocol facts and effects survive process interruption, and the safe behavior when recovery is incomplete. It does
+not define a database, snapshot format, transaction mechanism, scheduler, or serialization beyond existing Marmot and
+MLS wire encodings.
+
+`Retain` in this document means retain or be able to reconstruct from authenticated bytes and dependencies before the
+affected group resumes processing. An implementation MAY persist, derive, replay, or otherwise recover a fact. The
+observable requirement is the same protocol result after restart.
+
+The **protocol observer projection** is the complete per-group conformance view in
+[../foundation/conformance.md](../foundation/conformance.md): canonical state and lifecycle, convergence status, local
+protocol gates, unresolved publication, input outcomes, and effective application-visible outputs. It excludes the
+physical representation of those facts.
+
+## Recoverable protocol facts
+
+For each retained group, a client MUST retain or be able to reconstruct every fact still needed to continue the
+protocol without changing its result:
+
+- the last complete canonical group state, lifecycle state, and convergence status;
+- retained candidate-parent states and the cryptographic material required by
+  [retained-history.md](./retained-history.md);
+- each admitted protocol input's exact bytes, stable message identity, authenticated dependencies, and current
+  disposition while that disposition can still change, under
+  [inbound-processing.md](./inbound-processing.md);
+- enough identity, outcome, and effect information for terminally classified or already-accounted-for input to prevent
+  duplicate state application or duplicate application-visible output when the same bytes are encountered again;
+- every unresolved publish obligation, including the four protocol-relevant parts in
+  [publish-lifecycle.md](./publish-lifecycle.md), whether an external publish attempt might have occurred, and whether
+  the required acknowledgement is known to have succeeded;
+- local protocol gates and terminal local conditions that restrict legal actions, including `Leaving`, `Disbanding`,
+  local-leaf removal, `Unrecoverable`, and `Disbanded`; and
+- application-visible delivery, state-notification, withdrawal, and invalidation effects that have not yet been made
+  reconstructible to the application.
+
+An implementation MAY release a fact when no current or future protocol decision inside the applicable retention
+horizon, retry obligation, local gate, or application effect depends on it. Restart does not shorten any owning
+document's retention or release condition.
+
+## Restart equivalence
+
+A restart MUST NOT, by itself, change the canonical protocol-state projection defined in
+[../foundation/conformance.md](../foundation/conformance.md), change an input disposition, clear a local protocol gate,
+make unresolved outbound work successful, or make an application effect disappear.
+
+For convergence, given the same retained authenticated inputs and dependencies, a restarted client that continues
+executing MUST reach the same canonical protocol-state projection and dispositions as uninterrupted execution under
+the guarantees and assumptions in [convergence.md](./convergence.md) ("Guarantees and assumptions"). This requirement
+includes restart that changes local timer deadlines, pass partitioning, work ordering, or device speed. Those
+differences MAY delay an outcome or cause a different safe intermediate pass, but they MUST NOT change the eventual
+result after relevant input closes.
+
+If the client cannot yet reconstruct a required fact, it MUST keep the affected transition unapplied and outbound work
+blocked. For convergence work, temporary unavailability has the `Blocked` status; publish work remains in its current
+lifecycle state. Permanent loss or corruption follows "Missing or corrupt material" below.
+
+## Publish interruption boundaries
+
+Publication and canonical application remain separate protocol steps. Recovery follows the last boundary the client
+can establish from retained or reconstructed facts:
+
+1. **Prepared with no possible external publish.** Canonical state remains the prior state. The client MAY abandon the
+   preparation and return to `Stable`, or retry the exact obligation. It MUST NOT expose the pending state as canonical.
+2. **External acceptance possible, but acknowledgement unavailable after restart.** This includes bytes accepted by an
+   endpoint when confirmation was not retained or reconstructed. The client MUST treat the obligation as unresolved,
+   remain in `PendingPublish`, and MUST NOT assume either success or failure. It MAY republish the byte-identical
+   obligation to obtain a new acknowledgement satisfying the active transport rule. It MUST NOT replace the uncertain
+   obligation with newly generated Commit bytes.
+3. **Publication confirmed, canonical apply incomplete.** The client resumes `Merging` and applies the exact confirmed
+   pending transition once. Replaying its deterministic application from the last complete prior state is allowed. The
+   client MUST NOT generate a replacement Commit or expose a partially advanced canonical state.
+4. **Canonical apply complete, derived work incomplete.** The client keeps the applied canonical state and reconstructs
+   its dispositions, gates, notifications, deliveries, withdrawals, and invalidations. It MUST NOT reapply the Commit
+   or reopen `PendingPublish` merely to finish derived work.
+
+Before any publish attempt can make bytes externally observable, the exact obligation and the prior and pending states
+needed by cases 2 and 3 MUST be recoverable. Byte-identical republication is a retry of one obligation, not a new
+group-state change; duplicate handling still applies.
+
+If possible external acceptance cannot be excluded and the exact obligation or state needed to resolve it is
+permanently missing or corrupt, the client enters `Unrecoverable`. It MUST NOT discard the uncertainty, prepare another
+group-state change, or select the only locally complete branch merely because the possibly published branch is absent.
+
+## Convergence interruption boundaries
+
+A crash during convergence does not make admitted input invalid, stale, or unadmitted.
+
+- **Collection.** The client MAY resume the same collection window when its boundaries are reconstructible, or start a
+  new bounded pass over the still-eligible retained input. It MAY restart local collection timers. It MUST NOT omit an
+  admitted input merely because volatile pass membership or elapsed monotonic time was lost.
+- **Frozen-batch resolution.** The client MAY resume deterministic resolution of the exact frozen batch, or abandon the
+  wholly unapplied pass and admit all of its still-eligible inputs to a later pass. It MUST NOT resolve or apply an
+  accidental subset of the frozen batch. Later-retained input remains outside that batch unless a new pass is started.
+- **Selected-branch application.** The client MUST recover either the complete observer projection from before the
+  application or the complete projection after it, then finish or replay deterministic work from that boundary. It
+  MUST NOT expose a canonical state from one side with dispositions, gates, or application effects from the other.
+
+Loss of timer state or pass-membership metadata alone is not missing retained history when all admitted inputs and
+authenticated dependencies remain available. Loss or corruption of an admitted input, candidate-parent state, or
+dependency that could change selection is handled under "Missing or corrupt material" and MUST NOT be hidden by
+resolving the locally remaining branch.
+
+## Observer-atomic transitions
+
+The following multi-part changes MUST be atomic from the protocol observer's perspective:
+
+- preparing a local Commit makes both the pending state and its complete publish obligation available while leaving
+  canonical state unchanged;
+- selected-branch application changes canonical state, current dispositions, protocol gates or terminal conditions,
+  and the effective application output to one self-consistent projection;
+- realizing local-leaf removal changes the local condition and its application effect together; and
+- terminal disbanding establishes `Disbanded`, its authenticated tombstone, its single effective presentation effect,
+  and the prohibition on further group processing together.
+
+The lifecycle MAY expose `PendingPublish`, `Merging`, or `Recovering` while work is incomplete. During those states the
+last complete canonical projection remains authoritative. A client MUST NOT expose a partially applied transition.
+Physical writes MAY occur in any number and in any order that preserves this observer-visible rule.
+
+Safe replay reuses the same authenticated input or byte-identical publish obligation and is idempotent with respect to
+the effective projection. Regenerating a Commit with new randomness is a new protocol action, not replay, and is allowed
+only after the prior obligation is conclusively resolved and the lifecycle again permits preparation.
+
+## Missing or corrupt material
+
+On restart, a client first validates or reconstructs the facts required for the next affected transition. It then
+follows these outcomes:
+
+- If authenticated retained inputs and dependencies reproduce the fact, processing MAY continue from the reproduced
+  fact.
+- If the unavailable fact is temporary and no partial transition is exposed, the affected operation remains blocked;
+  convergence work has the `Blocked` status.
+- If material is outside its owning retention horizon and no unresolved work depends on it, ordinary pruning and stale
+  rules apply; its absence is not `Unrecoverable`.
+- If canonical state, a possibly published transition, or selection-relevant material inside the rollback horizon is
+  permanently missing or corrupt, the group enters `Unrecoverable`. Associated admitted input remains deferred with
+  `missing_history` as specified in [../foundation/errors.md](../foundation/errors.md).
+
+Partial recovery is not evidence for branch selection. A client in the last case MUST NOT select the only locally
+available branch, shorten the rollback horizon, discard an uncertain published branch, or convert affected input to a
+terminal disposition merely to resume operation. A verified repair, restore, explicit rejoin, or future specified
+recovery path is required.
+
+Loss of only derived disposition or application-effect records does not require `Unrecoverable` when the client can
+reconstruct them exactly from intact canonical state and admitted inputs. Until that reconstruction completes, the
+client MUST NOT claim `Settled` or expose a guessed projection.
+
+## Application effects after restart
+
+Application callbacks and acknowledgement APIs are implementation-defined. Their effective protocol view is not:
+
+- an accepted MLS application message has one effective delivered payload, keyed by its stable protocol message
+  identity;
+- a state notification derived from a Commit remains attributable to that Commit's `commit_digest`;
+- duplicate replay MUST NOT create a second effective delivery or state change;
+- an invalidated app payload or superseded state change remains withdrawn, and any required invalidation remains
+  observable until the application can reconstruct the selected-branch view; and
+- `group_disbanded` remains one effective presentation effect, while the leaf-scoped removal outcome remains
+  reconstructible under the suppression rule in [member-departure.md](./member-departure.md).
+
+After restart, a client MUST re-emit an effect whose observation was not established, or provide an equivalent
+reconstructible current projection. Re-emission uses the same stable input identity or `commit_digest` so repeated
+delivery can be deduplicated. A crash between canonical application and application observation does not cancel the
+effect, and a crash between prior observation and a later branch change does not cancel the required withdrawal or
+invalidation.

--- a/protocol-core/durability.md
+++ b/protocol-core/durability.md
@@ -81,9 +81,10 @@ Before any publish attempt can make bytes externally observable, the exact oblig
 needed by cases 2 and 3 MUST be recoverable. Byte-identical republication is a retry of one obligation, not a new
 group-state change; duplicate handling still applies.
 
-If possible external acceptance cannot be excluded and the exact obligation or state needed to resolve it is
-permanently missing or corrupt, the client enters `Unrecoverable`. It MUST NOT discard the uncertainty, prepare another
-group-state change, or select the only locally complete branch merely because the possibly published branch is absent.
+If possible external acceptance cannot be excluded, the exact obligation or state needed to resolve it is permanently
+missing or corrupt, and no verified repair path is available, the client enters `Unrecoverable`. It MUST NOT discard
+the uncertainty, prepare another group-state change, or select the only locally complete branch merely because the
+possibly published branch is absent.
 
 ## Convergence interruption boundaries
 
@@ -93,7 +94,8 @@ A crash during convergence does not make admitted input invalid, stale, or unadm
   new bounded pass over the still-eligible retained input. It MAY restart local collection timers. It MUST NOT omit an
   admitted input merely because volatile pass membership or elapsed monotonic time was lost.
 - **Frozen-batch resolution.** The client MAY resume deterministic resolution of the exact frozen batch, or abandon the
-  wholly unapplied pass and admit all of its still-eligible inputs to a later pass. It MUST NOT resolve or apply an
+  wholly unapplied pass and admit all of its still-eligible inputs and authenticated dependencies to a later pass under
+  the restart exception in [convergence.md](./convergence.md) ("Convergence policy"). It MUST NOT resolve or apply an
   accidental subset of the frozen batch. Later-retained input remains outside that batch unless a new pass is started.
 - **Selected-branch application.** The client MUST recover either the complete observer projection from before the
   application or the complete projection after it, then finish or replay deterministic work from that boundary. It
@@ -136,8 +138,9 @@ follows these outcomes:
 - If material is outside its owning retention horizon and no unresolved work depends on it, ordinary pruning and stale
   rules apply; its absence is not `Unrecoverable`.
 - If canonical state, a possibly published transition, or selection-relevant material inside the rollback horizon is
-  permanently missing or corrupt, the group enters `Unrecoverable`. Associated admitted input remains deferred with
-  `missing_history` as specified in [../foundation/errors.md](../foundation/errors.md).
+  permanently missing or corrupt and no verified repair path is available, the group enters `Unrecoverable`.
+  Associated admitted input remains deferred with `missing_history` as specified in
+  [../foundation/errors.md](../foundation/errors.md).
 
 Partial recovery is not evidence for branch selection. A client in the last case MUST NOT select the only locally
 available branch, shorten the rollback horizon, discard an uncertain published branch, or convert affected input to a
@@ -161,8 +164,30 @@ Application callbacks and acknowledgement APIs are implementation-defined. Their
 - `group_disbanded` remains one effective presentation effect, while the leaf-scoped removal outcome remains
   reconstructible under the suppression rule in [member-departure.md](./member-departure.md).
 
-After restart, a client MUST re-emit an effect whose observation was not established, or provide an equivalent
-reconstructible current projection. Re-emission uses the same stable input identity or `commit_digest` so repeated
-delivery can be deduplicated. A crash between canonical application and application observation does not cancel the
-effect, and a crash between prior observation and a later branch change does not cancel the required withdrawal or
-invalidation.
+Each effect has a stable effect identity. For a delivered or invalidated app payload, it is the effect kind plus the
+stable protocol message identity. For a state notification derived from a Commit, it is the effect kind plus that
+Commit's `commit_digest` and, when the Commit produces more than one effect of that kind, the canonical protocol
+identity of the affected leaf, component, or other subject. A state-change withdrawal uses the effect kind plus the
+identity of the notification it withdraws. A group-state invalidation uses the effect kind plus the superseded Commit's
+`commit_digest`. Distinct effect kinds remain distinct when they refer to the same input or Commit. A branch-recovery
+notification that is not attributed to one Commit uses the effect kind plus the optional superseded canonical tip
+Commit digest and the selected tip Commit digest; absence of a superseded tip digest is part of the identity. Any
+future effect not covered here MUST define an equivalent deterministic identity from the accepted protocol inputs and
+selected state that produce it; it MUST NOT use local receipt order, scheduling order, or a local storage identifier.
+
+An effect's observation boundary is established only when the client can recover its stable effect identity together
+with either:
+
+- an application acknowledgement for that identity; or
+- an equivalent recoverable selected-branch projection through which the application reconstructs the current
+  effective outputs.
+
+The acknowledgement shape and projection-access mechanism are implementation-defined. A client that relies on the
+second option MUST re-expose the recovered projection after restart before suppressing re-emission. Merely invoking a
+callback, attempting delivery, or recording the effect without one of these two conditions does not establish
+observation.
+
+After restart, a client MUST re-emit an effect whose observation boundary was not established, or re-expose the
+equivalent reconstructible current projection. Re-emission uses the same stable effect identity so repeated delivery
+can be deduplicated. A crash between canonical application and application observation does not cancel the effect, and
+a crash between prior observation and a later branch change does not cancel the required withdrawal or invalidation.

--- a/protocol-core/group-state.md
+++ b/protocol-core/group-state.md
@@ -15,7 +15,8 @@ The group lifecycle has six states:
 - `Merging`: publication was confirmed, and the client is applying the staged commit to its local canonical state.
 - `Recovering`: the client is selecting a safe branch from retained state after detecting a fork-shaped conflict or
   admitting a valid disband candidate that requires terminal convergence.
-- `Unrecoverable`: the client cannot safely select a branch from its retained local material.
+- `Unrecoverable`: the client cannot safely establish canonical state or resolve an in-flight transition from its
+  retained local material.
 - `Disbanded`: an authenticated disband Commit was selected by a bounded convergence pass. The group is terminal,
   read-only, and cannot resume or rejoin under the same group id.
 
@@ -59,8 +60,12 @@ PendingPublish
   -> Merging             publish obligation confirmed
 PendingPublish
   -> Stable              publish obligation failed or was abandoned
+PendingPublish
+  -> Unrecoverable       possibly published transition cannot be safely reconstructed
 Merging
   -> Stable              staged commit applied
+Merging
+  -> Unrecoverable       confirmed transition cannot be safely completed or rolled back
 Stable
   -> Recovering          fork detected, or valid disband candidate admitted
 Stable
@@ -116,17 +121,23 @@ the selected branch has been applied and the lifecycle returns to `Stable`.
 
 ## Unrecoverable cases
 
-A client enters `Unrecoverable` when it cannot determine the canonical branch without violating the group's retention or
-validation rules.
+A client enters `Unrecoverable` when it cannot safely establish canonical protocol state or complete an unresolved
+state transition without violating the group's retention or validation rules.
 
 Examples include:
 
 - the client needs a retained state inside the rollback horizon, but that state is missing;
 - the client cannot validate any candidate branch from the retained anchor;
-- local group state is corrupted and cannot validate the retained commit path.
+- local group state is corrupted and cannot validate the retained commit path;
+- a possibly published local transition cannot be reconstructed; or
+- an interrupted selected-branch application cannot be completed or restored to its prior complete projection.
 
 A client in `Unrecoverable` MUST NOT choose the current local state merely because it is the only state available. It
 MUST stop applying group-state changes until it has a verified repair path.
+
+The same fail-closed rule applies after restart when a possibly published local transition, frozen convergence input,
+or selected-branch application cannot be reconstructed. The complete restart classification is in
+[durability.md](./durability.md) ("Missing or corrupt material").
 
 A repair path MAY restore retained state, rejoin through MLS, or use another recovery method defined by a future
 protocol-core document.

--- a/protocol-core/group-state.md
+++ b/protocol-core/group-state.md
@@ -15,8 +15,8 @@ The group lifecycle has six states:
 - `Merging`: publication was confirmed, and the client is applying the staged commit to its local canonical state.
 - `Recovering`: the client is selecting a safe branch from retained state after detecting a fork-shaped conflict or
   admitting a valid disband candidate that requires terminal convergence.
-- `Unrecoverable`: the client cannot safely establish canonical state or resolve an in-flight transition from its
-  retained local material.
+- `Unrecoverable`: required retained material is permanently missing or corrupt, no verified repair path is available,
+  and the client therefore cannot safely establish canonical state or resolve an in-flight transition.
 - `Disbanded`: an authenticated disband Commit was selected by a bounded convergence pass. The group is terminal,
   read-only, and cannot resume or rejoin under the same group id.
 
@@ -61,21 +61,21 @@ PendingPublish
 PendingPublish
   -> Stable              publish obligation failed or was abandoned
 PendingPublish
-  -> Unrecoverable       possibly published transition cannot be safely reconstructed
+  -> Unrecoverable       possibly published transition is permanently missing or corrupt with no verified repair path
 Merging
   -> Stable              staged commit applied
 Merging
-  -> Unrecoverable       confirmed transition cannot be safely completed or rolled back
+  -> Unrecoverable       confirmed transition material is permanently missing or corrupt with no verified repair path
 Stable
   -> Recovering          fork detected, or valid disband candidate admitted
 Stable
-  -> Unrecoverable       required retained state is permanently missing or corrupt
+  -> Unrecoverable       required state is permanently missing or corrupt with no verified repair path
 Recovering
   -> Stable              a canonical branch was selected and applied
 Recovering
   -> Disbanded           a selected branch terminates the group
 Recovering
-  -> Unrecoverable       no safe branch can be selected from retained local material
+  -> Unrecoverable       required branch material is permanently missing or corrupt with no verified repair path
 Unrecoverable
   -> Stable              state was repaired, restored, or replaced by a verified join
 Disbanded
@@ -93,7 +93,8 @@ client is applying its own confirmed commit is retained, the merge completes to 
 bounded pass then triggers the applicable `Stable -> Recovering` rule. `Recovering` re-entry is implicit:
 convergence-relevant input that arrives while the group is already in `Recovering` and before the bounded pass cutoff is
 folded into that recovery pass. Input retained after the cutoff belongs to a later pass. The group stays in `Recovering`
-until a branch is selected and applied (`-> Stable` or `-> Disbanded`) or no safe branch exists (`-> Unrecoverable`).
+until a branch is selected and applied (`-> Stable` or `-> Disbanded`) or required branch material is permanently
+missing or corrupt and no verified repair path is available (`-> Unrecoverable`).
 
 The direct `Stable -> Unrecoverable` transition applies when normal linear processing discovers that required retained
 history or authenticated state inside the rollback horizon is permanently unavailable or corrupt and no defined
@@ -122,22 +123,24 @@ the selected branch has been applied and the lifecycle returns to `Stable`.
 ## Unrecoverable cases
 
 A client enters `Unrecoverable` when it cannot safely establish canonical protocol state or complete an unresolved
-state transition without violating the group's retention or validation rules.
+state transition because required material is permanently missing or corrupt and no verified repair path is available.
 
 Examples include:
 
-- the client needs a retained state inside the rollback horizon, but that state is missing;
-- the client cannot validate any candidate branch from the retained anchor;
-- local group state is corrupted and cannot validate the retained commit path;
-- a possibly published local transition cannot be reconstructed; or
-- an interrupted selected-branch application cannot be completed or restored to its prior complete projection.
+- a retained state inside the rollback horizon is permanently missing;
+- required material is missing or corrupt, so the client cannot validate any candidate branch from the retained anchor;
+- local group state is corrupt and cannot validate the retained commit path;
+- a possibly published local transition is permanently unavailable and cannot be reconstructed; or
+- required material for an interrupted selected-branch application is permanently unavailable, so the application
+  can be neither completed nor restored to its prior complete projection.
 
 A client in `Unrecoverable` MUST NOT choose the current local state merely because it is the only state available. It
 MUST stop applying group-state changes until it has a verified repair path.
 
-The same fail-closed rule applies after restart when a possibly published local transition, frozen convergence input,
-or selected-branch application cannot be reconstructed. The complete restart classification is in
-[durability.md](./durability.md) ("Missing or corrupt material").
+After restart, the complete classification in [durability.md](./durability.md) ("Missing or corrupt material") applies.
+Temporary unavailability keeps the current lifecycle and blocks the affected work. A wholly unapplied frozen batch MAY
+instead be abandoned and recollected only under the all-input restart exception in that document. Permanent loss or
+corruption changes the lifecycle to `Unrecoverable` only when no verified repair path is available.
 
 A repair path MAY restore retained state, rejoin through MLS, or use another recovery method defined by a future
 protocol-core document.

--- a/protocol-core/inbound-processing.md
+++ b/protocol-core/inbound-processing.md
@@ -151,3 +151,6 @@ the retained app-payload window.
 
 A Marmot app payload whose MLS application message decrypts only on a losing branch MUST be reported as invalidated, not
 delivered as accepted application output.
+
+Restart does not cancel a delivery, notification, withdrawal, or invalidation effect. Re-emission, deduplication, and
+reconstruction follow [durability.md](./durability.md) ("Application effects after restart").

--- a/protocol-core/publish-lifecycle.md
+++ b/protocol-core/publish-lifecycle.md
@@ -98,3 +98,11 @@ eligible remaining member, as long as the proposal has not been consumed by an a
 retained history.
 
 If another member publishes an equivalent or conflicting commit first, ordinary convergence decides the result.
+
+## Restart
+
+A process interruption does not resolve a publish obligation. Recovery of prepared, acknowledgement-uncertain,
+confirmed-but-unapplied, and applied-but-underived transitions follows
+[durability.md](./durability.md) ("Publish interruption boundaries"). In particular, possible external acceptance
+without a recoverable acknowledgement is still `PendingPublish`, and safe retry republishes the byte-identical
+obligation rather than generating a replacement Commit.

--- a/protocol-core/retained-history.md
+++ b/protocol-core/retained-history.md
@@ -21,6 +21,10 @@ At minimum, a client needs retained state for:
 - any staged local commit waiting for publish confirmation;
 - any candidate parent state still needed by deferred input inside the rollback horizon.
 
+These candidate-replay requirements are part of the broader restart contract in
+[durability.md](./durability.md). That document also owns recoverability of admitted input, unresolved publication,
+local protocol gates, and application effects; it does not extend the cryptographic release conditions below.
+
 ## Retained cryptographic material
 
 Retained group state is functional state, not an instruction to snapshot every secret an MLS implementation exposes.


### PR DESCRIPTION
## Summary

- add a focused protocol-core durability and restart contract covering recoverable logical facts, restart equivalence, publish interruption boundaries, convergence interruption boundaries, observer-atomic transitions, missing or corrupt material, and application-effect recovery
- add crash/restart conformance scenarios for publish-before-apply, convergence collection and resolution, selected-branch application, local gates, terminal effects, and incomplete retained material
- cross-link retained history, convergence, publish lifecycle, group state, inbound processing, errors, principles, surface indexes, and the non-normative implementation model

## Why

The adopted documents already define deterministic convergence, retained candidate-parent material, publish-before-apply, durable leaving/disbanding gates, and fail-closed missing-history behavior. They did not define one unambiguous contract for process interruption at the seams between those rules. In particular, externally accepted but unconfirmed publication, interrupted selected-branch application, and incomplete application effects could otherwise produce implementation-dependent protocol results after restart.

This change defines the observable behavior and what must remain reproducible while leaving transactions, journals, snapshots, replay strategy, schedulers, and physical storage formats implementation-defined. It explicitly does not require one snapshot per epoch.

## Protocol impact

- no wire encoding changes
- no component or registry changes
- no database or snapshot encoding is standardized
- restart must not change canonical branch selection, input dispositions, unresolved outbound gates, or the effective application-visible projection

## Validation

- `git diff --check`
- local Markdown link validation for all changed documents
- repository-required implementation-detail and transport-leak scans, with every match reviewed as an existing boundary statement, implementation-model entry, or transport-independence rule


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive durability and crash-recovery guidance across the protocol specifications.
  - Defined restart-equivalent outcomes for publication, acknowledgements, convergence, application effects, and delivery.
  - Clarified observer-atomic state transitions, safe replay, and prevention of duplicated or lost effects.
  - Documented fail-closed handling for missing or corrupted retained history.
  - Expanded conformance guidance with crash, restart, corruption, and terminal-state testing scenarios.
  - Clarified unrecoverable lifecycle outcomes and byte-identical retry behavior for interrupted publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->